### PR TITLE
fix(ui): set full width for calendar card to remove redundant space

### DIFF
--- a/src/layouts/calendar/calendar.tsx
+++ b/src/layouts/calendar/calendar.tsx
@@ -34,7 +34,7 @@ const PersianCalendar: React.FC = () => {
 			className="flex flex-col justify-center w-full h-full gap-3 mb-1 sm:h-80 md:flex-row sm:"
 			dir="rtl"
 		>
-			<CalendarContainer className="w-full overflow-hidden max-w-96 md:w-7/12 md:flex-1">
+			<CalendarContainer className="w-full overflow-hidden  md:w-7/12 md:flex-1">
 				<CalendarHeader
 					currentDate={currentDate}
 					setCurrentDate={setCurrentDate}


### PR DESCRIPTION
related to https://github.com/widgetify-app/widgetify-extension/issues/28