### PR TITLE
ui(title): set text-neutral-900 for widgetify title in dark mode

### DIFF
--- a/src/layouts/navbar/navbar.layout.tsx
+++ b/src/layouts/navbar/navbar.layout.tsx
@@ -37,7 +37,7 @@ export function NavbarLayout(): JSX.Element {
 		<>
 			<nav className="flex items-center justify-between px-4 py-2">
 				<div className="flex items-center">
-					<h1 className="text-2xl text-gray-100">ویجتی‌فای</h1>
+					<h1 className="text-2xl text-gray-100 dark:text-neutral-900">ویجتی‌فای</h1>
 				</div>
 				<div className="flex items-center gap-2">
 					<FriendsList />


### PR DESCRIPTION
مربوط به https://github.com/widgetify-app/widgetify-extension/issues/49