### PR TITLE
refactor: convert SyncButton to ProfileButton and integrate with friends panel

### DIFF
--- a/src/layouts/navbar/friends-list/friends.tsx
+++ b/src/layouts/navbar/friends-list/friends.tsx
@@ -1,6 +1,5 @@
 import { Colors } from '@/common/constant/colors.constant'
 import { FiChevronLeft, FiUsers } from 'react-icons/fi'
-import { LiaUsersCogSolid } from 'react-icons/lia'
 import { FreeMode, Navigation } from 'swiper/modules'
 import { Swiper, SwiperSlide } from 'swiper/react'
 //@ts-ignore
@@ -9,13 +8,12 @@ import { AuthRequiredModal } from '@/components/auth/AuthRequiredModal'
 import Tooltip from '@/components/toolTip'
 import { useAuth } from '@/context/auth.context'
 import { useGetFriends } from '@/services/hooks/friends/friendService.hook'
-import { useGetUserProfile } from '@/services/hooks/user/userService.hook'
 import { useState } from 'react'
+import { ProfileButton } from '../sync/sync'
 import { FriendItem } from './friend.item'
 import { FriendSettingModal } from './setting/friend-setting.modal'
 
 export function FriendsList() {
-	const { data: user } = useGetUserProfile()
 	const [showFriendsList, setShowFriendsList] = useState(false)
 	const [firstAuth, setFirstAuth] = useState<boolean>(false)
 	const [showSettingsModal, setShowSettingsModal] = useState(false)
@@ -50,33 +48,22 @@ export function FriendsList() {
 						<FiChevronLeft size={16} />
 					</button>
 				)}
-				{!showFriendsList && (
-					<div className="flex items-center justify-around w-full">
-						<Tooltip content="نمایش دوستان" position="bottom">
-							<button
-								className="p-0.5 cursor-pointer border-l border-gray-300/50"
-								onClick={() => setShowFriendsList(!showFriendsList)}
-							>
-								<FiUsers className="ml-1" size={18} />
-								{}
-							</button>
-						</Tooltip>
-						<span className="h-full w-0.5 px-0.5"></span>
-						<Tooltip content="مدیریت دوستان">
-							<button
-								className="p-0.5 cursor-pointer relative"
-								onClick={handleOpenSettingsModal}
-							>
-								<LiaUsersCogSolid size={18} />
-								{user && user?.friendshipStats?.pending > 0 && (
-									<div className="absolute flex items-center justify-center w-4 h-4 text-[.6rem] font-bold text-white bg-red-500 rounded-full -bottom-1 -right-1 p-0.5 text-center">
-										{user?.friendshipStats.pending}
-									</div>
-								)}
-							</button>
-						</Tooltip>
-					</div>
-				)}{' '}
+
+				<div
+					className={`flex items-center justify-around w-full ${showFriendsList && 'hidden'}`}
+				>
+					<Tooltip content="نمایش دوستان" position="bottom">
+						<button
+							className="p-0.5 cursor-pointer border-l border-gray-300/50"
+							onClick={() => setShowFriendsList(!showFriendsList)}
+						>
+							<FiUsers className="ml-1 transition-all hover:scale-80" size={14} />
+						</button>
+					</Tooltip>
+					<span className="h-full w-0.5 px-0.5"></span>
+					<ProfileButton onClick={handleOpenSettingsModal} />
+				</div>
+
 				<Swiper
 					modules={[FreeMode, Navigation]}
 					spaceBetween={2}
@@ -105,6 +92,7 @@ export function FriendsList() {
 
 			<FriendSettingModal
 				isOpen={showSettingsModal}
+				selectedTab={'profile'}
 				onClose={() => {
 					setShowSettingsModal(false)
 					refetchFriends()
@@ -114,7 +102,7 @@ export function FriendsList() {
 				isOpen={firstAuth}
 				onClose={() => setFirstAuth(false)}
 				title="ورود به حساب کاربری"
-				message="برای دسترسی به بخش مدیریت دوستان، ابتدا وارد حساب کاربری خود شوید."
+				message="برای دسترسی به بخش حساب کاربری و مدیریت دوستان، ابتدا وارد حساب کاربری خود شوید."
 				loginButtonText="ورود به حساب"
 				cancelButtonText="بعداً"
 			/>

--- a/src/layouts/navbar/friends-list/setting/friend-setting.modal.tsx
+++ b/src/layouts/navbar/friends-list/setting/friend-setting.modal.tsx
@@ -22,19 +22,6 @@ export const FriendSettingModal = ({
 
 	const tabs: TabItem[] = [
 		{
-			label: 'همه دوستان',
-			value: 'all',
-			icon: <FiUsers size={20} />,
-			element: <AllFriendsTab />,
-		},
-		{
-			label: 'درخواست‌ها',
-			value: 'requests',
-			icon: <FiUserCheck size={20} />,
-			element: <FriendRequestsTab />,
-		},
-
-		{
 			label: 'پروفایل من',
 			value: 'profile',
 			icon: <BiUserCircle size={20} />,
@@ -45,6 +32,18 @@ export const FriendSettingModal = ({
 					برای مشاهده پروفایل خود ابتدا وارد حساب کاربری شوید
 				</div>
 			),
+		},
+		{
+			label: 'همه دوستان',
+			value: 'all',
+			icon: <FiUsers size={20} />,
+			element: <AllFriendsTab />,
+		},
+		{
+			label: 'درخواست‌ها',
+			value: 'requests',
+			icon: <FiUserCheck size={20} />,
+			element: <FriendRequestsTab />,
 		},
 	]
 

--- a/src/layouts/navbar/navbar.layout.tsx
+++ b/src/layouts/navbar/navbar.layout.tsx
@@ -7,7 +7,6 @@ import { TbApps } from 'react-icons/tb'
 import { VscSettings } from 'react-icons/vsc'
 import { SettingModal } from '../setting/setting-modal'
 import { FriendsList } from './friends-list/friends'
-import { SyncButton } from './sync/sync'
 
 export interface PageLink {
 	name: string
@@ -42,7 +41,6 @@ export function NavbarLayout(): JSX.Element {
 				<div className="flex items-center gap-2">
 					<FriendsList />
 
-					<SyncButton />
 					<Tooltip content="مدیریت ویجت‌ها">
 						<button
 							className={`flex items-center justify-center cursor-pointer w-10 h-10 text-gray-300 transition-all border shadow-lg rounded-xl hover:text-gray-200 hover:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 ${Colors.bgItemGlass}`}

--- a/src/layouts/navbar/sync/sync.tsx
+++ b/src/layouts/navbar/sync/sync.tsx
@@ -1,4 +1,3 @@
-import { Colors } from '@/common/constant/colors.constant'
 import { getFromStorage, setToStorage } from '@/common/storage'
 import { callEvent } from '@/common/utils/call-event'
 import { AuthRequiredModal } from '@/components/auth/AuthRequiredModal'
@@ -19,6 +18,7 @@ import { AnimatePresence, LazyMotion, domAnimation, m } from 'framer-motion'
 import { useEffect, useRef, useState } from 'react'
 import { AiOutlineCloudSync, AiOutlineSync } from 'react-icons/ai'
 import { BiCheck } from 'react-icons/bi'
+import { LiaUsersCogSolid } from 'react-icons/lia'
 
 enum SyncState {
 	Syncing = 0,
@@ -31,8 +31,10 @@ export enum SyncTarget {
 	TODOS = 1,
 	BOOKMARKS = 2,
 }
-
-export function SyncButton() {
+interface Props {
+	onClick: () => void
+}
+export function ProfileButton(props: Props) {
 	const [firstAuth, setFirstAuth] = useState<boolean>(false)
 	const [syncState, setSyncState] = useState<SyncState | null>(null)
 	const { isAuthenticated } = useAuth()
@@ -162,7 +164,7 @@ export function SyncButton() {
 
 		if (syncState === SyncState.Error) return 'خطا در همگام‌سازی'
 
-		return 'همگام‌سازی با حساب کاربری'
+		return 'حساب کاربری و مدیریت دوستان'
 	}
 
 	return (
@@ -171,26 +173,16 @@ export function SyncButton() {
 				<div className="relative group">
 					<LazyMotion features={domAnimation}>
 						<m.button
-							className={`flex items-center justify-center cursor-pointer w-10 h-10 text-gray-300 transition-all border shadow-lg rounded-xl hover:text-gray-200 hover:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 ${Colors.bgItemGlass}`}
-							onClick={() => syncData(SyncTarget.ALL, 'POST')}
+							className={
+								'flex items-center hover:scale-80 justify-center cursor-pointer w-8 h-8 transition-all  hover:text-gray-200 hover:border hover:border-blue-400  rounded-full focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50'
+							}
+							onClick={props.onClick}
 							aria-label="Sync"
 							whileHover={{ scale: 1.05 }}
 							whileTap={{ scale: 0.95 }}
 							transition={{ type: 'spring', stiffness: 400, damping: 17 }}
 						>
 							<AnimatePresence mode="wait">
-								{user?.avatar && syncState === null && (
-									<m.div
-										className="absolute flex items-center justify-center w-4 h-4 bg-blue-500 border border-gray-800 rounded-full -bottom-1 -right-1"
-										initial={{ scale: 0, opacity: 0 }}
-										animate={{ scale: 1, opacity: 1 }}
-										exit={{ scale: 0, opacity: 0 }}
-										transition={{ duration: 0.2 }}
-									>
-										<AiOutlineCloudSync size={10} className="text-white" />
-									</m.div>
-								)}
-
 								{syncState === SyncState.Syncing ? (
 									<m.div
 										className="flex items-center justify-center"
@@ -255,13 +247,7 @@ export function SyncButton() {
 												transition={{ type: 'spring', stiffness: 300, damping: 15 }}
 											/>
 										) : (
-											<m.div
-												initial={{ scale: 0.8, opacity: 0.5 }}
-												animate={{ scale: 1, opacity: 1 }}
-												transition={{ type: 'spring', stiffness: 300, damping: 15 }}
-											>
-												<AiOutlineCloudSync size={22} />
-											</m.div>
+											<LiaUsersCogSolid size={16} />
 										)}
 									</m.div>
 								)}


### PR DESCRIPTION
refactor: convert SyncButton to ProfileButton and integrate with friends panel

- Replaced SyncButton with ProfileButton component in friends list
- Removed standalone SyncButton from navbar
- Rearranged friend settings modal tabs to show profile first
- Added selectedTab prop to FriendSettingModal
- Updated UI styling for better integration
![image](https://github.com/user-attachments/assets/fb5d8e04-0130-4871-ab02-2c9fccdfeb24)
