### PR TITLE
refactor(news): replace CORS proxy with dedicated RSS API endpoint

### DIFF
--- a/src/layouts/widgets/news/utils/rss.utils.ts
+++ b/src/layouts/widgets/news/utils/rss.utils.ts
@@ -1,3 +1,4 @@
+import { GetRss } from '@/services/rss/rss.api'
 import axios from 'axios'
 import type { RssItem } from '../news.interface'
 
@@ -12,8 +13,7 @@ export const fetchRssFeed = async (
 	sourceName: string,
 ): Promise<RssItem[]> => {
 	try {
-		const corsProxy = 'https://api.allorigins.win/raw?url='
-		const response = await axios.get(`${corsProxy}${url}`)
+		const response = await GetRss(url)
 
 		const text = response.data
 		const parser = new DOMParser()

--- a/src/services/rss/rss.api.ts
+++ b/src/services/rss/rss.api.ts
@@ -1,0 +1,11 @@
+import { getMainClient } from '../api'
+
+export async function GetRss(url: string) {
+	const api = await getMainClient()
+	const result = await api.get('/rss', {
+		params: {
+			url: url,
+		},
+	})
+	return result.data
+}


### PR DESCRIPTION
- Remove dependency on external CORS proxy (api.allorigins.win)
- Implement dedicated RSS fetching service via backend API
- Improve security and reliability by using our own backend endpoint