### PR TITLE
Refactor Todos Widget 

### DIFF
--- a/src/layouts/widgetify-card/overviewCards/todo-overviewCard.tsx
+++ b/src/layouts/widgetify-card/overviewCards/todo-overviewCard.tsx
@@ -35,7 +35,7 @@ export function TodoOverviewCard() {
 
 	return (
 		<motion.div
-			className={'p-1 rounded-lg bg-content shadow-sm'}
+			className={'p-1 rounded-lg bg-content'}
 			initial={{ opacity: 0, y: 5 }}
 			animate={{ opacity: 1, y: 0 }}
 			transition={{ delay: 0.4 }}
@@ -47,9 +47,9 @@ export function TodoOverviewCard() {
 				<div className="flex-1">
 					<p className="text-xs font-medium">{getTodoLabel('full')}</p>
 					{todoOptions.blurMode ? (
-						<p className="text-xs opacity-75">حالت مخفی فعال است.</p>
+						<p className="text-[10px] opacity-75">حالت مخفی فعال است.</p>
 					) : (
-						<p className="text-xs opacity-75">
+						<p className="text-[10px] opacity-75">
 							{pendingTodos.length > 0
 								? `${completedTodos.length} از ${todayTodos.length} وظیفه تکمیل شده`
 								: todayTodos.length > 0

--- a/src/layouts/widgets/comboWidget/combo-widget.layout.tsx
+++ b/src/layouts/widgets/comboWidget/combo-widget.layout.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/button/button'
 import { NewsLayout } from '../news/news.layout'
 import { WidgetContainer } from '../widget-container'
 import { WigiArzLayout } from '../wigiArz/wigi_arz.layout'
+import { LuNewspaper } from 'react-icons/lu'
 
 export function ComboWidget() {
 	const [activeTab, setActiveTab] = useState<'news' | 'currency'>('currency')
@@ -14,31 +15,40 @@ export function ComboWidget() {
 	}
 
 	return (
-		<WidgetContainer className={'flex flex-col gap-1 py-2'}>
-			<div className="flex items-center justify-between px-2 pb-2 border-b border-content">
-				<div className="flex gap-6 w-44">
+		<WidgetContainer className={'flex flex-col gap-1'}>
+			<div className="flex items-center justify-between">
+				<div className="flex gap-2 w-full">
 					<button
 						onClick={() => setActiveTab('currency')}
-						className={`py-1.5 hover:opacity-70 cursor-pointer text-sm flex items-center gap-1.5 font-medium transition-all opacity-75 active:scale-95 ${activeTab === 'currency' && 'opacity-100'}`}
+						className={`flex items-center gap-1 px-2.5 py-1 text-xs font-medium whitespace-nowrap transition-colors cursor-pointer rounded-[0.55rem] active:scale-95 ${
+							activeTab === 'currency'
+								? 'bg-primary text-white'
+								: 'text-muted hover:bg-base-300'
+						}
+								`}
 					>
-						<FiDollarSign className="w-3.5 h-3.5" />
+						<FiDollarSign className="w-3 h-3" />
 						<span>ارزها</span>
 					</button>
 					<button
 						onClick={() => setActiveTab('news')}
-						className={`py-1.5 hover:opacity-70 cursor-pointer text-sm flex items-center gap-1.5 font-medium transition-all opacity-75 active:scale-95 ${activeTab === 'news' && 'opacity-100'}`}
+						className={`flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium whitespace-nowrap transition-colors cursor-pointer rounded-[0.55rem] active:scale-95 ${
+							activeTab === 'news'
+								? 'bg-primary text-white'
+								: 'text-muted hover:bg-base-300'
+						}
+								`}
 					>
-						<FiBook className="w-3.5 h-3.5" />
+						<LuNewspaper className="w-3 h-3" />
 						<span>اخبار</span>
 					</button>
 				</div>
 				<Button
 					onClick={handleSettingsClick}
 					size="xs"
-					className="btn-ghost"
-					rounded="xl"
+					className="ml-3 h-6 w-6 p-0 flex items-center justify-center rounded-full !border-none !shadow-none"
 				>
-					<FiSettings />
+					<FiSettings size={12} className="text-content" />
 				</Button>
 			</div>
 

--- a/src/layouts/widgets/todos/expandable-todo-input.tsx
+++ b/src/layouts/widgets/todos/expandable-todo-input.tsx
@@ -97,37 +97,31 @@ export function ExpandableTodoInput({
 	}
 
 	return (
-		<div ref={containerRef} className="flex-none pt-2 mt-auto">
-			<div
-				className={`rounded-lg overflow-hidden  ${
-					isExpanded ? 'border border-content' : ''
-				}`}
-			>
-				<div className="flex items-center gap-1 p-2">
+		<div ref={containerRef} className="flex-none pt-3 mt-auto">
+			<div className={`rounded-xl overflow-hidden`}>
+				<div className="p-2 flex items-center gap-1 rounded-xl bg-base-300">
 					<div className="flex-grow w-full">
 						<TextInput
 							ref={inputRef}
 							value={todoText}
 							onChange={onChangeTodoText}
 							placeholder="عنوان وظیفه جدید..."
-							className="w-full py-1.5 text-sm !rounded-lg"
+							className="!h-6 !border-none !outline-none !shadow-none !ring-0 w-full p-0 text-sm !rounded-lg !bg-transparent"
 							onFocus={handleInputFocus}
 							onKeyDown={handleKeyDown}
 							id="expandable-todo-input"
 						/>
-					</div>{' '}
-					<div className="flex flex-col items-center flex-shrink-0  gap-0.5">
-						<Button
-							onClick={handleAddTodo}
-							disabled={!todoText.trim()}
-							size="md"
-							isPrimary={true}
-							rounded="md"
-							className="p-2"
-						>
-							<FiPlus size={16} />
-						</Button>
 					</div>
+					<Button
+						onClick={handleAddTodo}
+						disabled={!todoText.trim()}
+						size="sm"
+						isPrimary={true}
+						rounded="lg"
+						className="p-1.5 h-7 !bg-none"
+					>
+						<FiPlus size={16} />
+					</Button>
 				</div>
 
 				<AnimatePresence>
@@ -138,7 +132,7 @@ export function ExpandableTodoInput({
 							exit={{ opacity: 0, height: 0 }}
 							transition={{ duration: 0.2 }}
 						>
-							<div className="px-3 pb-3 space-y-3">
+							<div className="px-2 py-3 space-y-3">
 								<div>
 									<label
 										className={
@@ -184,28 +178,34 @@ export function ExpandableTodoInput({
 									</div>
 								</div>{' '}
 								<div className="mt-2 space-y-2">
-									<div className="flex items-center gap-2">
-										<div className="flex-shrink-0 w-5 text-center">
-											<FiTag className="text-indigo-400" />
+									<div className="flex items-center gap-3">
+										<div className="flex-shrink-0 text-center">
+											<FiTag
+												className="text-indigo-400"
+												size={16}
+											/>
 										</div>
 										<TextInput
 											type="text"
 											value={category}
 											onChange={(value) => setCategory(value)}
 											placeholder="دسته‌بندی (مثال: شخصی، کاری)"
-											className="text-xs py-1.5"
+											className="text-xs placeholder:text-xs py-1.5"
 										/>
 									</div>
 
-									<div className="flex items-start gap-2">
-										<div className="flex-shrink-0 w-5 mt-2 text-center">
-											<FiMessageSquare className="text-indigo-400" />
+									<div className="flex items-center gap-3">
+										<div className="flex-shrink-0 text-center">
+											<FiMessageSquare
+												className="text-indigo-400"
+												size={16}
+											/>
 										</div>
 										<TextInput
 											value={notes}
 											onChange={(value) => setNotes(value)}
 											placeholder="یادداشت یا توضیحات تکمیلی..."
-											className="text-xs py-1.5"
+											className="text-xs placeholder:text-xs py-1.5"
 										/>
 									</div>
 								</div>

--- a/src/layouts/widgets/todos/todo.item.tsx
+++ b/src/layouts/widgets/todos/todo.item.tsx
@@ -22,13 +22,13 @@ export function TodoItem({ todo, deleteTodo, toggleTodo, blurMode = false }: Pro
 	const getBorderStyle = () => {
 		switch (todo.priority) {
 			case 'high':
-				return 'border-error'
+				return '!border-error'
 			case 'medium':
-				return 'border-warning'
+				return '!border-warning'
 			case 'low':
-				return 'border-success'
+				return '!border-success'
 			default:
-				return 'border-primary'
+				return '!border-primary'
 		}
 	}
 
@@ -46,13 +46,14 @@ export function TodoItem({ todo, deleteTodo, toggleTodo, blurMode = false }: Pro
 	}
 	return (
 		<div
-			className={`overflow-hidden rounded-lg transition delay-150 duration-300 ease-in-out border-r-2 ${getBorderStyle()} bg-content group ${blurMode ? 'blur-item' : ''}`}
+			className={`overflow-hidden rounded-lg transition delay-150 duration-300 ease-in-out bg-content group ${blurMode ? 'blur-item' : ''}`}
 		>
 			<div className={'flex items-center gap-1.5 pr-1.5 p-1.5'}>
 				<div className="flex-shrink-0">
 					<CustomCheckbox
 						checked={todo.completed}
 						onChange={() => toggleTodo(todo.id)}
+						className={`!border ${getBorderStyle()}`}
 					/>
 				</div>
 
@@ -64,27 +65,26 @@ export function TodoItem({ todo, deleteTodo, toggleTodo, blurMode = false }: Pro
 				</span>
 
 				{/* Actions */}
-				<div className="flex items-center">
-					<button
-						onClick={() => setExpanded(!expanded)}
-						className={
-							'p-0.5 rounded-full cursor-pointer hover:bg-gray-500/10 text-gray-400'
-						}
-					>
-						{expanded ? (
-							<FiChevronUp size={12} />
-						) : (
-							<FiChevronDown size={12} />
-						)}
-					</button>
-
+				<div className="flex items-center gap-x-1">
 					<button
 						onClick={() => deleteTodo(todo.id)}
 						className={
-							'p-0.5 rounded-full cursor-pointer hover:bg-red-500/10 transition-opacity opacity-0 group-hover:opacity-100 text-red-400'
+							'p-1 rounded-full cursor-pointer hover:bg-red-500/10 opacity-0 group-hover:opacity-100 transition-all duration-200 delay-100 group-hover:select-none text-red-400'
 						}
 					>
-						<FiTrash2 size={12} />
+						<FiTrash2 size={13} />
+					</button>
+
+					<button
+						onClick={() => setExpanded(!expanded)}
+						className={
+							'p-1 rounded-full cursor-pointer hover:bg-gray-500/10 text-gray-400'
+						}
+					>
+						<FiChevronDown
+							size={14}
+							className={`${expanded ? 'rotate-0' : 'rotate-180'} transition-transform duration-300`}
+						/>
 					</button>
 				</div>
 			</div>{' '}

--- a/src/layouts/widgets/todos/todos.tsx
+++ b/src/layouts/widgets/todos/todos.tsx
@@ -80,24 +80,24 @@ export function TodosLayout() {
 							</span>
 						</h4>
 
-						<div className="flex gap-1">
+						<div className="flex gap-1.5">
+							<Button
+								onClick={() => setShowStats(!showStats)}
+								size="xs"
+								className={`h-7 w-7 text-xs font-medium rounded-[0.55rem] transition-colors border-none shadow-none ${showStats ? 'bg-primary text-white' : 'text-muted hover:bg-base-300'}`}
+							>
+								<FaChartSimple size={12} />
+							</Button>
 							<Button
 								onClick={handleBlurModeToggle}
 								size="xs"
-								isPrimary={todoOptions.blurMode}
+								className={`h-7 w-7 text-xs font-medium rounded-[0.55rem] transition-colors border-none shadow-none ${todoOptions.blurMode ? 'bg-primary text-white' : 'text-muted hover:bg-base-300'}`}
 							>
 								{todoOptions.blurMode ? (
 									<FaEye size={12} />
 								) : (
 									<FaEyeSlash size={12} />
 								)}
-							</Button>
-							<Button
-								onClick={() => setShowStats(!showStats)}
-								isPrimary={showStats}
-								size="xs"
-							>
-								<FaChartSimple size={12} />
 							</Button>
 						</div>
 					</div>
@@ -106,53 +106,26 @@ export function TodosLayout() {
 						<TodoStats />
 					) : (
 						<>
-							{selectedDateTodos.length > 0 && (
-								<div className="mb-2">
-									<div className={'h-1 mb-1 rounded-full bg-base-200'}>
-										<div
-											className="h-1 bg-green-500 rounded-full"
-											style={{ width: `${stats.percentage}%` }}
-										></div>
-									</div>
-									<div
-										className={
-											'flex justify-between text-[.65rem] text-content'
-										}
-									>
-										<span>
-											{stats.completed} از {stats.total} تکمیل شده
-										</span>
-										<span>{stats.percentage}%</span>
-									</div>
-								</div>
-							)}
-
 							<div className="flex justify-between mb-2">
 								<div className="flex gap-0.5 text-xs">
-									<Button
+									<button
 										onClick={() => setFilter('all')}
-										className={`px-1 py-0.5 ${filter === 'all' ? 'btn-soft' : 'btn-ghost text-muted'}`}
-										rounded="sm"
-										size="xs"
+										className={`px-2 py-0.5 rounded-full border-none text-[10px] cursor-pointer active:scale-95 ${filter === 'all' ? 'bg-primary text-white' : 'text-muted bg-base-300'}`}
 									>
 										همه
-									</Button>
-									<Button
+									</button>
+									<button
 										onClick={() => setFilter('active')}
-										className={`px-1 py-0.5 ${filter === 'active' ? 'btn-soft' : 'btn-ghost text-muted'}`}
-										rounded="sm"
-										size="xs"
+										className={`px-2 py-0.5 rounded-full border-none text-[10px] cursor-pointer active:scale-95 ${filter === 'active' ? 'bg-primary text-white' : 'text-muted bg-base-300'}`}
 									>
 										فعال
-									</Button>
-									<Button
+									</button>
+									<button
 										onClick={() => setFilter('completed')}
-										className={`px-1 py-0.5 ${filter === 'completed' ? 'btn-soft' : 'btn-ghost text-muted'}`}
-										rounded="sm"
-										size="xs"
+										className={`px-2 py-0.5 rounded-full border-none text-[10px] cursor-pointer active:scale-95 ${filter === 'completed' ? 'bg-primary text-white' : 'text-muted bg-base-300'}`}
 									>
 										تکمیل شده
-									</Button>
+									</button>
 								</div>
 								<select
 									value={todoOptions.viewMode}
@@ -162,14 +135,14 @@ export function TodosLayout() {
 										)
 									}
 									className={
-										'select select-xs text-[.65rem] w-24 bg-content !px-2 focus:outline-none focus:border focus:border-primary'
+										'select select-xs text-[10px] w-[5.5rem] !px-2.5 rounded-xl !outline-none !border-none !shadow-none text-muted bg-base-300 cursor-pointer'
 									}
 									style={{
 										backgroundImage: `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3e%3c/svg%3e")`,
 										backgroundPosition: 'left 0.5rem center',
 										backgroundRepeat: 'no-repeat',
-										backgroundSize: '1.5em 1.5em',
-										paddingLeft: '2.5rem',
+										backgroundSize: '1.3em 1.3em',
+										paddingLeft: '3rem',
 									}}
 								>
 									<option


### PR DESCRIPTION
In this commit:

- Aligned the todos widget's UI with new design
- Added a new style for expandable input 

Screenshots:

![Screenshot 1404-04-05 at 17 31 37](https://github.com/user-attachments/assets/ca6022ac-8e37-42a4-a885-1dcf027e5e9a)
![Screenshot 1404-04-05 at 17 31 43](https://github.com/user-attachments/assets/487edbe1-1931-4d44-a28b-af4865c6115a)
![Screenshot 1404-04-05 at 17 31 51](https://github.com/user-attachments/assets/f8b0c6fc-4bd3-4b48-827f-93fc898f81d5)
