### PR TITLE
feat: add drag-and-drop support to move bookmark into folder

### DIFF
--- a/src/layouts/bookmark/bookmarks.tsx
+++ b/src/layouts/bookmark/bookmarks.tsx
@@ -158,54 +158,85 @@ export function BookmarksComponent() {
 		setDragOverIndex(null)
 	}
 
-	const handleDrop = (e: React.DragEvent<HTMLDivElement>, targetIndex: number) => {
-		e.preventDefault()
+ const handleDrop = ( e: React.DragEvent<HTMLDivElement>, targetIndex: number) => {
+    e.preventDefault();
 
-		if (!draggedBookmarkId) return
+    if (!draggedBookmarkId) return;
 
-		const currentItems = getCurrentFolderItems(currentFolderId)
-		const sourceIndex = currentItems.findIndex(
-			(item) => item.id === draggedBookmarkId
-		)
+    const allBookmarks = [...bookmarks];
+    const currentItems = getCurrentFolderItems(currentFolderId);
+    const sourceBookmark = allBookmarks.find((b) => b.id === draggedBookmarkId);
+    const targetBookmark = currentItems[targetIndex];
 
-		if (sourceIndex === -1 || sourceIndex === targetIndex) {
-			setDraggedBookmarkId(null)
-			setDragOverIndex(null)
-			return
-		}
+    if (!sourceBookmark) {
+      setDraggedBookmarkId(null);
+      setDragOverIndex(null);
+      return;
+    }
 
-		const allBookmarks = [...bookmarks]
+    if (targetBookmark && targetBookmark.type === "FOLDER") {
+      if (sourceBookmark.parentId !== targetBookmark.id) {
+        const updatedSourceIndex = allBookmarks.findIndex(
+          (b) => b.id === draggedBookmarkId
+        );
 
-		const sourceBookmark = currentItems[sourceIndex]
-		const actualSourceIndex = allBookmarks.findIndex(
-			(b) => b.id === sourceBookmark.id
-		)
-		const targetBookmark = currentItems[targetIndex]
-		const actualTargetIndex = allBookmarks.findIndex(
-			(b) => b.id === targetBookmark.id
-		)
+        if (updatedSourceIndex !== -1) {
+          const updatedBookmark = {
+            ...allBookmarks[updatedSourceIndex],
+            parentId: targetBookmark.id, 
+            order: 0, 
+          };
 
-		if (actualSourceIndex !== -1 && actualTargetIndex !== -1) {
-			const [movedBookmark] = allBookmarks.splice(actualSourceIndex, 1)
+          allBookmarks[updatedSourceIndex] = updatedBookmark;
+          setBookmarks(allBookmarks);
+          debouncedSync();
+        }
+      }
+    } else {
+      const sourceIndex = currentItems.findIndex(
+        (item) => item.id === draggedBookmarkId
+      );
 
-			allBookmarks.splice(actualTargetIndex, 0, movedBookmark)
+      if (sourceIndex === -1 || sourceIndex === targetIndex) {
+        setDraggedBookmarkId(null);
+        setDragOverIndex(null);
+        return;
+      }
 
-			const updatedBookmarks = allBookmarks.map((bookmark) => {
-				if (bookmark.parentId === currentFolderId) {
-					const newIndex = allBookmarks.findIndex((b) => b.id === bookmark.id)
-					return { ...bookmark, order: newIndex }
-				}
-				return bookmark
-			})
+      const sourceBookmarkForReorder = currentItems[sourceIndex];
+      const actualSourceIndex = allBookmarks.findIndex(
+        (b) => b.id === sourceBookmarkForReorder.id
+      );
+      const targetBookmarkForReorder =
+        targetIndex < currentItems.length ? currentItems[targetIndex] : null;
+      if (actualSourceIndex !== -1 && targetBookmarkForReorder) {
+        const actualTargetIndex = allBookmarks.findIndex(
+          (b) => b.id === targetBookmarkForReorder.id
+        );
 
-			setBookmarks(updatedBookmarks)
+        if (actualTargetIndex !== -1) {
+          const [movedBookmark] = allBookmarks.splice(actualSourceIndex, 1);
+          allBookmarks.splice(actualTargetIndex, 0, movedBookmark);
 
-			debouncedSync()
-		}
+          const updatedBookmarks = allBookmarks.map((bookmark) => {
+            if (bookmark.parentId === currentFolderId) {
+              const newIndex = allBookmarks.findIndex(
+                (b) => b.id === bookmark.id
+              );
+              return { ...bookmark, order: newIndex };
+            }
+            return bookmark;
+          });
 
-		setDraggedBookmarkId(null)
-		setDragOverIndex(null)
-	}
+          setBookmarks(updatedBookmarks);
+          debouncedSync();
+        }
+      }
+    }
+
+    setDraggedBookmarkId(null);
+    setDragOverIndex(null);
+  };
 
 	const handleNavigate = (folderId: string | null, depth: number) => {
 		if (depth === -1) {
@@ -287,7 +318,6 @@ export function BookmarksComponent() {
 						>
 							<BookmarkItem
 								bookmark={bookmark}
-								onMouseDown={(e) => handleBookmarkClick(bookmark, e)}
 								onClick={(e) => {
 									if (e?.button === 0) handleBookmarkClick(bookmark, e)
 								}}


### PR DESCRIPTION
# Feature: Add drag-and-drop support for moving bookmarks into folders

## Description

This PR introduces the ability to **drag and drop bookmarks to move them into folders**.

## Problem

Previously, users could not move existing bookmarks into folders. Bookmarks could only be created inside folders but couldn’t be moved afterward. This limited bookmark organization and flexibility.

## Improvement

Now users can directly move bookmarks into folders via drag-and-drop, enhancing bookmark management and usability.

## Solution

- Implement drag-and-drop functionality for moving bookmarks between folders.
