### PR TITLE
feat: add usage count display and improve wallpaper gallery navigation

### DIFF
--- a/src/common/wallpaper.interface.ts
+++ b/src/common/wallpaper.interface.ts
@@ -8,6 +8,7 @@ export interface Wallpaper {
 	source?: string
 	gradient?: GradientColors
 	categoryId?: string
+	usageCount?: number
 }
 
 export interface GradientColors {

--- a/src/layouts/setting/tabs/wallpapers/hooks/use-wallpapers-by-category.ts
+++ b/src/layouts/setting/tabs/wallpapers/hooks/use-wallpapers-by-category.ts
@@ -1,13 +1,8 @@
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useRef, useState } from 'react'
 import type { Category, Wallpaper } from '@/common/wallpaper.interface'
 import { getMainClient } from '@/services/api'
 import { useGetWallpaperCategories } from '@/services/hooks/wallpapers/getWallpaperCategories.hook'
-import { useQuery } from '@tanstack/react-query'
-import { useEffect, useRef, useState } from 'react'
-
-interface CategoryWallpapers {
-	category: Category
-	wallpapers: Wallpaper[]
-}
 
 interface WallpaperResponse {
 	wallpapers: Wallpaper[]
@@ -71,18 +66,12 @@ export function useWallpapersByCategory() {
 		return allWallpapers.filter((wallpaper) => wallpaper.categoryId === categoryId)
 	}
 
-	const wallpapersByCategory = () => {
-		if (!wallpapers || selectedCategoryId === null) return []
+	const getSelectedCategory = (): Category | null => {
+		if (!wallpapers || selectedCategoryId === null) return null
 
 		const selectedCategory = categories.find((cat) => cat.id === selectedCategoryId)
-		if (!selectedCategory) return []
-
-		return [
-			{
-				category: selectedCategory,
-				wallpapers: wallpapers,
-			},
-		] as CategoryWallpapers[]
+		if (!selectedCategory) return null
+		return selectedCategory
 	}
 
 	const allWallpapers = wallpapers || []
@@ -92,7 +81,7 @@ export function useWallpapersByCategory() {
 
 	return {
 		categories,
-		wallpapersByCategory,
+		getSelectedCategory,
 		allWallpapers,
 		isLoading,
 		error,

--- a/src/layouts/setting/tabs/wallpapers/item.wallpaper.tsx
+++ b/src/layouts/setting/tabs/wallpapers/item.wallpaper.tsx
@@ -1,6 +1,7 @@
-import type { Wallpaper } from '@/common/wallpaper.interface'
 import React, { useEffect, useRef, useState } from 'react'
+import { FaUsers } from 'react-icons/fa'
 import { FiCheck, FiHeart } from 'react-icons/fi'
+import type { Wallpaper } from '@/common/wallpaper.interface'
 import { useLazyLoad } from './hooks/use-lazy-load'
 
 interface WallpaperItemProps {
@@ -42,10 +43,6 @@ export const WallpaperItem = React.memo(
 
 		const getSelectionBadgeStyle = () => {
 			return 'bg-primary text-white shadow-lg'
-		}
-
-		const getInfoLayerStyle = () => {
-			return 'bg-gradient-to-t from-black/70 to-black/0'
 		}
 
 		useEffect(() => {
@@ -113,13 +110,19 @@ export const WallpaperItem = React.memo(
 				{loaded && !error && (
 					<>
 						<div
-							className={`absolute inset-x-0 bottom-0 p-2 transition-opacity duration-300 opacity-0 group-hover:opacity-100 ${getInfoLayerStyle()}`}
+							className={`absolute flex justify-between inset-x-0 bottom-0 p-2 transition-opacity duration-300 bg-gradient-to-t from-black/80 to-black/0 items-center`}
 						>
 							{wallpaper.name && (
 								<p className="text-xs font-medium text-white">
 									{wallpaper.name}
 								</p>
 							)}
+							{
+								<div className="text-xs text-center text-content">
+									<FaUsers />
+									<span>{wallpaper.usageCount}</span>
+								</div>
+							}
 						</div>
 
 						{isSelected && (

--- a/src/layouts/setting/tabs/wallpapers/tab/gallery.tab.tsx
+++ b/src/layouts/setting/tabs/wallpapers/tab/gallery.tab.tsx
@@ -1,9 +1,9 @@
+import { useEffect, useState } from 'react'
+import { FiFolder } from 'react-icons/fi'
 import { preloadImages } from '@/common/utils/preloadImages'
-import { Button } from '@/components/button/button'
 import { SectionPanel } from '@/components/section-panel'
 import { useAuth } from '@/context/auth.context'
-import { useEffect, useState } from 'react'
-import { FiArrowLeft, FiFolder } from 'react-icons/fi'
+import { FolderPath } from '@/layouts/bookmark/components/folder-path'
 import { RetouchFilter } from '../components/retouch-filter.component'
 import { UploadArea } from '../components/upload-area.component'
 import { WallpaperGallery } from '../components/wallpaper-gallery.component'
@@ -21,6 +21,7 @@ export function GalleryTab() {
 		selectedCategoryId,
 		changeCategory,
 		getCategoryWallpapers,
+		getSelectedCategory,
 	} = useWallpapersByCategory()
 
 	const {
@@ -55,6 +56,8 @@ export function GalleryTab() {
 			preloadImages(imageUrls)
 		}
 	}, [allWallpapers])
+
+	const selectedCategory = getSelectedCategory()
 
 	interface FolderProps {
 		id: string
@@ -106,10 +109,17 @@ export function GalleryTab() {
 
 	function BackButton() {
 		return (
-			<Button onClick={() => handleBackToCategories()} size="sm">
-				<FiArrowLeft size={16} />
-				<span>بازگشت به فولدرها</span>
-			</Button>
+			<div className="flex justify-center mt-1">
+				<FolderPath
+					folderPath={[
+						{
+							id: 'subfolder',
+							title: selectedCategory?.name || 'پوشه',
+						},
+					]}
+					onNavigate={() => handleBackToCategories()}
+				/>
+			</div>
 		)
 	}
 
@@ -132,7 +142,6 @@ export function GalleryTab() {
 						</div>
 					) : (
 						<div key="wallpaper-view">
-							<BackButton />
 							<WallpaperGallery
 								isLoading={isLoading}
 								error={error}
@@ -140,6 +149,7 @@ export function GalleryTab() {
 								selectedBackground={selectedBackground}
 								onSelectBackground={handleSelectBackground}
 							/>
+							<BackButton />
 						</div>
 					)}
 				</div>


### PR DESCRIPTION
- Add usageCount field to Wallpaper interface
- Display usage count with user icon in wallpaper items
- Replace category-based data structure with direct category selection
- Improve navigation with FolderPath component instead of simple back button
- Move back button to bottom of gallery for better UX
- Remove unused CategoryWallpapers interface and getInfoLayerStyle function
- Update wallpaper item overlay to always show with better styling