### PR TITLE
feat: add currency color mode toggle for price change indicators

### DIFF
--- a/src/common/constant/store.key.ts
+++ b/src/common/constant/store.key.ts
@@ -26,9 +26,11 @@ import type {
 } from '@/services/hooks/weather/weather.interface'
 import type { FetchedYouTubeProfile } from '@/services/hooks/youtube/getYouTubeProfile.hook'
 import type { StoredWallpaper, Wallpaper } from '../wallpaper.interface'
+import { CurrencyColorMode } from '@/context/currency.context'
 
 export interface StorageKV {
 	currencies: string[]
+	currencyColorMode: CurrencyColorMode
 	hasShownPwaModal: boolean
 	selectedCity: SelectedCity | null
 	currentWeather: FetchedWeather

--- a/src/layouts/widgets/wigiArz/components/addCurrency-box.tsx
+++ b/src/layouts/widgets/wigiArz/components/addCurrency-box.tsx
@@ -1,8 +1,10 @@
 import Analytics from '@/analytics'
 import { Button } from '@/components/button/button'
+import { ItemSelector } from '@/components/item-selector'
 import Modal from '@/components/modal'
+import { SectionPanel } from '@/components/section-panel'
 import { TextInput } from '@/components/text-input'
-import { useCurrencyStore } from '@/context/currency.context'
+import { CurrencyColorMode, useCurrencyStore } from '@/context/currency.context'
 import { useGetSupportCurrencies } from '@/services/hooks/currency/getSupportCurrencies.hook'
 import { useEffect, useState } from 'react'
 import { FiSearch } from 'react-icons/fi'
@@ -23,10 +25,14 @@ interface AddCurrencyModalProps {
 }
 
 export function SelectCurrencyModal({ setShow, show }: AddCurrencyModalProps) {
-	if (!show) return null
 	const { data: supportCurrencies } = useGetSupportCurrencies()
 
-	const { selectedCurrencies, setSelectedCurrencies } = useCurrencyStore()
+	const {
+		selectedCurrencies,
+		setSelectedCurrencies,
+		currencyColorMode,
+		setCurrencyColorMode,
+	} = useCurrencyStore()
 	const [searchQuery, setSearchQuery] = useState('')
 	const [isContentVisible, setIsContentVisible] = useState(false)
 
@@ -68,6 +74,10 @@ export function SelectCurrencyModal({ setShow, show }: AddCurrencyModalProps) {
 		)
 	}
 
+	const toggleCurrencyColorMode = (mode: CurrencyColorMode) => {
+		setCurrencyColorMode(mode)
+	}
+
 	const currencyGroups = getCurrencyOptions(supportCurrencies)
 	const filteredGroups = currencyGroups
 		.map((group) => ({
@@ -78,88 +88,113 @@ export function SelectCurrencyModal({ setShow, show }: AddCurrencyModalProps) {
 		}))
 		.filter((group) => group.options.length > 0)
 
+	if (!show) return null
+
 	return (
 		<Modal
 			isOpen={show}
 			onClose={onClose}
 			size="md"
-			title="افزودن ارز"
+			title="مدیریت ویجی‌ارز"
 			direction="rtl"
 		>
 			<div
 				className={`w-full h-full transition-all duration-300 ease-out ${isContentVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-[20px]'}`}
 			>
-				<div className="relative mb-5">
-					<div
-						className={`absolute text-gray-400 transform -translate-y-1/2 left-3 top-1/2 transition-opacity duration-300 ease-out ${isContentVisible ? 'opacity-100 delay-200' : 'opacity-0'}`}
-					>
-						<FiSearch />
+				<SectionPanel title="رنگ تغییر قیمت" size="xs">
+					<div className="flex flex-row  gap-2">
+						<ItemSelector
+							label="عادی"
+							isActive={currencyColorMode === CurrencyColorMode.NORMAL}
+							className="w-full"
+							onClick={() =>
+								toggleCurrencyColorMode(CurrencyColorMode.NORMAL)
+							}
+						/>
+						<ItemSelector
+							label="معکوس"
+							isActive={currencyColorMode === CurrencyColorMode.X}
+							className="w-full"
+							onClick={() => toggleCurrencyColorMode(CurrencyColorMode.X)}
+						/>
 					</div>
-					<TextInput
-						type="text"
-						value={searchQuery}
-						onChange={(e) => setSearchQuery(e)}
-						placeholder="جستجو ..."
-					/>
-				</div>
+				</SectionPanel>
 
-				<div
-					className={`px-2 pr-1 overflow-x-hidden overflow-y-auto min-h-60 max-h-60 scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent transition-opacity duration-300 ease-out ${isContentVisible ? 'opacity-100 delay-[100ms]' : 'opacity-0'}`}
-				>
-					{filteredGroups.map((group, groupIndex) => (
+				<SectionPanel title="ارزها" size="xs">
+					<div className="relative mb-5">
 						<div
-							key={groupIndex}
-							className={`mb-6 transition-all duration-200 ease-out ${isContentVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-[10px]'}`}
-							style={{
-								transitionDelay: isContentVisible
-									? `${200 + groupIndex * 100}ms`
-									: '0ms',
-							}}
+							className={`absolute text-gray-400 transform -translate-y-1/2 left-3 top-1/2 transition-opacity duration-300 ease-out ${isContentVisible ? 'opacity-100 delay-200' : 'opacity-0'}`}
 						>
-							<h3
-								className={
-									'text-sm font-medium mb-3 currency-group-heading'
-								}
-							>
-								{group.label}
-							</h3>
-							<div className="grid grid-cols-2 gap-3 md:grid-cols-3">
-								{group.options.map((option) => {
-									const isSelected = selectedCurrencies.includes(
-										option.value
-									)
+							<FiSearch />
+						</div>
+						<TextInput
+							type="text"
+							value={searchQuery}
+							onChange={(e) => setSearchQuery(e)}
+							placeholder="جستجو ..."
+						/>
+					</div>
 
-									return (
-										<div
-											key={option.value}
-											className={`flex flex-col items-center justify-center gap-1 p-3 border cursor-pointer rounded-xl 
+					<div
+						className={`px-2 pr-1 overflow-x-hidden overflow-y-auto min-h-60 max-h-60 scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent transition-opacity duration-300 ease-out ${isContentVisible ? 'opacity-100 delay-[100ms]' : 'opacity-0'}`}
+					>
+						{filteredGroups.map((group, groupIndex) => (
+							<div
+								key={groupIndex}
+								className={`mb-6 transition-all duration-200 ease-out ${isContentVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-[10px]'}`}
+								style={{
+									transitionDelay: isContentVisible
+										? `${200 + groupIndex * 100}ms`
+										: '0ms',
+								}}
+							>
+								<h3
+									className={
+										'text-sm font-medium mb-3 currency-group-heading'
+									}
+								>
+									{group.label}
+								</h3>
+								<div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+									{group.options.map((option) => {
+										const isSelected = selectedCurrencies.includes(
+											option.value
+										)
+
+										return (
+											<div
+												key={option.value}
+												className={`flex flex-col items-center justify-center gap-1 p-3 border cursor-pointer rounded-xl 
                                                         transition-all duration-200 ease-out active:scale-98 
                                                         ${isSelected ? 'currency-box-selected border-success/30 bg-success/15 text-content' : 'border-base-300/40 bg-content hover:!bg-base-300/70'}
                                                         ${isContentVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-[10px]'}`}
-											style={{
-												transitionDelay: isContentVisible
-													? `${10 + groupIndex * 100 + 50}ms`
-													: '0ms',
-											}}
-											onClick={() => toggleCurrency(option.value)}
-										>
-											<div
-												className={`font-normal ${isSelected ? 'font-medium' : ''}`}
+												style={{
+													transitionDelay: isContentVisible
+														? `${10 + groupIndex * 100 + 50}ms`
+														: '0ms',
+												}}
+												onClick={() =>
+													toggleCurrency(option.value)
+												}
 											>
-												{option.label}
+												<div
+													className={`font-normal ${isSelected ? 'font-medium' : ''}`}
+												>
+													{option.label}
+												</div>
+												<div
+													className={`text-xs font-light opacity-70 ${isSelected ? 'opacity-90' : ''}`}
+												>
+													{option.value}
+												</div>
 											</div>
-											<div
-												className={`text-xs font-light opacity-70 ${isSelected ? 'opacity-90' : ''}`}
-											>
-												{option.value}
-											</div>
-										</div>
-									)
-								})}
+										)
+									})}
+								</div>
 							</div>
-						</div>
-					))}
-				</div>
+						))}
+					</div>
+				</SectionPanel>
 
 				<div
 					className={`mt-4 flex justify-center w-full transition-all duration-300 ease-out ${isContentVisible ? 'opacity-100 translate-y-0 delay-[600ms]' : 'opacity-0 translate-y-[10px]'}`}

--- a/src/layouts/widgets/wigiArz/components/currency-box.tsx
+++ b/src/layouts/widgets/wigiArz/components/currency-box.tsx
@@ -9,12 +9,14 @@ import { useEffect, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
 import { FaArrowDownLong, FaArrowUpLong } from 'react-icons/fa6'
 import { CurrencyModalComponent } from './currency-modal'
+import { CurrencyColorMode } from '@/context/currency.context'
 
 interface CurrencyBoxProps {
 	code: string
+	currencyColorMode: CurrencyColorMode | null
 }
 
-export const CurrencyBox = ({ code }: CurrencyBoxProps) => {
+export const CurrencyBox = ({ code, currencyColorMode }: CurrencyBoxProps) => {
 	const { data, dataUpdatedAt } = useGetCurrencyByCode(code, {
 		refetchInterval: null,
 	})
@@ -95,6 +97,11 @@ export const CurrencyBox = ({ code }: CurrencyBoxProps) => {
 		}
 	}
 
+	const priceChangeColor =
+		currencyColorMode === CurrencyColorMode.NORMAL
+			? `${priceChange > 0 ? 'text-red-500' : 'text-green-500'}`
+			: `${priceChange > 0 ? 'text-green-500' : 'text-red-500'}`
+
 	return (
 		<>
 			<div
@@ -122,13 +129,7 @@ export const CurrencyBox = ({ code }: CurrencyBoxProps) => {
 						/>
 					</div>
 					<div className="flex items-center space-x-2 text-sm font-medium min-w-0">
-						<span
-							className="block text-content opacity-90 truncate"
-							title={currency?.name?.en}
-						>
-							{currency?.name?.en}
-						</span>
-						<span className="block text-xs text-content truncate opacity-40">
+						<span className="block text-sm text-content truncate">
 							{code}
 						</span>
 					</div>
@@ -136,12 +137,10 @@ export const CurrencyBox = ({ code }: CurrencyBoxProps) => {
 
 				<div className="pr-2 flex items-baseline gap-2">
 					<span className={'text-sm font-bold text-content'}>
-						{displayPrice.toLocaleString()}
+						{displayPrice ? displayPrice.toLocaleString() : '-'}
 					</span>
 					{priceChange !== 0 && (
-						<span
-							className={`text-xs ${priceChange > 0 ? 'text-red-500' : 'text-green-500'}`}
-						>
+						<span className={`text-xs ${priceChangeColor}`}>
 							{priceChange > 0 ? (
 								<FaArrowUpLong className="inline" />
 							) : (
@@ -154,6 +153,7 @@ export const CurrencyBox = ({ code }: CurrencyBoxProps) => {
 			{currency && !currency.url && (
 				<CurrencyModalComponent
 					code={code}
+					currencyColorMode={currencyColorMode}
 					priceChange={priceChange}
 					currency={currency}
 					displayPrice={displayPrice}

--- a/src/layouts/widgets/wigiArz/components/currency-modal.tsx
+++ b/src/layouts/widgets/wigiArz/components/currency-modal.tsx
@@ -3,6 +3,7 @@ import Modal from '@/components/modal'
 import { useEffect, useState } from 'react'
 import { FaArrowDownLong, FaArrowUpLong, FaChartLine } from 'react-icons/fa6'
 import { CurrencyChart } from './currency-chart'
+import { CurrencyColorMode } from '@/context/currency.context'
 
 interface CurrencyModalComponentProps {
 	code: string
@@ -10,7 +11,8 @@ interface CurrencyModalComponentProps {
 	displayPrice: number
 	imgMainColor: string | undefined
 	isModalOpen: boolean
-	priceChange: number | null
+	priceChange: number
+	currencyColorMode: CurrencyColorMode | null
 	toggleCurrencyModal: () => void
 }
 
@@ -22,6 +24,7 @@ export const CurrencyModalComponent = ({
 	isModalOpen,
 	priceChange,
 	toggleCurrencyModal,
+	currencyColorMode,
 }: CurrencyModalComponentProps) => {
 	const [showChart, setShowChart] = useState(true)
 	const [isVisible, setIsVisible] = useState(false)
@@ -37,6 +40,11 @@ export const CurrencyModalComponent = ({
 		}
 		return () => clearTimeout(timerId)
 	}, [isModalOpen])
+
+	const priceChangeColor =
+		currencyColorMode === CurrencyColorMode.NORMAL
+			? `${priceChange > 0 ? 'text-red-500' : 'text-green-500'}`
+			: `${priceChange > 0 ? 'text-green-500' : 'text-red-500'}`
 
 	return (
 		<Modal isOpen={isModalOpen} onClose={toggleCurrencyModal} size="md">
@@ -68,7 +76,18 @@ export const CurrencyModalComponent = ({
 
 				<div className="w-full space-y-0">
 					<div className="relative flex items-center justify-center gap-2 transition-transform duration-150 ease-out hover:scale-102">
-						<PriceChangeComponent priceChange={priceChange} />
+						<div
+							className={`flex items-center text-sm transition-all duration-300 ease-out ${priceChangeColor}`}
+						>
+							{priceChange > 0 ? (
+								<FaArrowUpLong className="mr-1" />
+							) : (
+								<FaArrowDownLong className="mr-1" />
+							)}
+
+							<span>{Math.abs(Number(priceChange.toFixed()))}</span>
+						</div>
+
 						<p className={'text-xl font-bold text-base-content opacity-95'}>
 							{displayPrice.toLocaleString()}
 						</p>
@@ -108,36 +127,5 @@ export const CurrencyModalComponent = ({
 				</div>
 			</div>
 		</Modal>
-	)
-}
-
-interface Prop {
-	priceChange: number | null
-}
-
-export function PriceChangeComponent({ priceChange }: Prop) {
-	if (priceChange === null) return null
-	const [hasAnimatedIn, setHasAnimatedIn] = useState(false)
-
-	useEffect(() => {
-		// Animate in shortly after mount
-		const timer = setTimeout(() => setHasAnimatedIn(true), 50)
-		return () => clearTimeout(timer)
-	}, [])
-
-	return (
-		<div
-			className={`flex items-center text-sm transition-all duration-300 ease-out ${
-				priceChange > 0 ? 'text-red-500' : 'text-green-500'
-			} ${hasAnimatedIn ? 'translate-y-0 opacity-100' : '-translate-y-2.5 opacity-0'}`}
-		>
-			{priceChange > 0 ? (
-				<FaArrowUpLong className="mr-1" />
-			) : (
-				<FaArrowDownLong className="mr-1" />
-			)}
-
-			<span>{Math.abs(Number(priceChange.toFixed()))}</span>
-		</div>
 	)
 }

--- a/src/layouts/widgets/wigiArz/wigi_arz.layout.tsx
+++ b/src/layouts/widgets/wigiArz/wigi_arz.layout.tsx
@@ -20,7 +20,7 @@ export function WigiArzLayout({
 	onSettingsModalClose,
 	inComboWidget,
 }: WigiArzLayoutProps) {
-	const { selectedCurrencies } = useCurrencyStore()
+	const { selectedCurrencies, currencyColorMode } = useCurrencyStore()
 	const [showModal, setShowModal] = useState(false)
 
 	useEffect(() => {
@@ -77,6 +77,7 @@ export function WigiArzLayout({
 									<CurrencyBox
 										code={currency}
 										key={`${currency}-${index}`}
+										currencyColorMode={currencyColorMode}
 									/>
 								</div>
 							))}
@@ -130,6 +131,7 @@ export function WigiArzLayout({
 									<CurrencyBox
 										code={currency}
 										key={`${currency}-${index}`}
+										currencyColorMode={currencyColorMode}
 									/>
 								</div>
 							))}


### PR DESCRIPTION
- Add CurrencyColorMode enum with NORMAL and X options
- Implement currency color mode state management in currency context
- Add color mode selection UI in currency settings modal
- Update currency components to support configurable price change colors
- Add persistence for currency color mode preference in storage
- Allow users to toggle between standard (red=up, green=down) and inverted color schemes