### PR TITLE
Add general hide mode to widgetify, info panel, notes, todos

### DIFF
--- a/src/context/general-setting.context.tsx
+++ b/src/context/general-setting.context.tsx
@@ -4,6 +4,7 @@ import { getFromStorage, setToStorage } from '@/common/storage'
 import type { FetchedTimezone } from '@/services/hooks/timezone/getTimezones.hook'
 
 export interface GeneralData {
+	blurMode: boolean
 	analyticsEnabled: boolean
 	selected_timezone: FetchedTimezone
 }
@@ -15,6 +16,7 @@ interface GeneralSettingContextType extends GeneralData {
 }
 
 const DEFAULT_SETTINGS: GeneralData = {
+	blurMode: false,
 	analyticsEnabled: true,
 	selected_timezone: {
 		label: 'آسیا / تهران',
@@ -78,6 +80,7 @@ export function GeneralSettingProvider({ children }: { children: React.ReactNode
 		return null
 	}
 	const contextValue: GeneralSettingContextType = {
+		blurMode: settings.blurMode,
 		analyticsEnabled: settings.analyticsEnabled,
 		selected_timezone:
 			settings?.selected_timezone || DEFAULT_SETTINGS.selected_timezone,

--- a/src/context/todo.context.tsx
+++ b/src/context/todo.context.tsx
@@ -16,7 +16,6 @@ export enum TodoPriority {
 	High = 'high',
 }
 export interface TodoOptions {
-	blurMode: boolean
 	viewMode: TodoViewType
 }
 export interface AddTodoInput {
@@ -43,7 +42,6 @@ const TodoContext = createContext<TodoContextType | null>(null)
 export function TodoProvider({ children }: { children: React.ReactNode }) {
 	const [todos, setTodos] = useState<Todo[] | null>(null)
 	const [todoOptions, setTodoOptions] = useState<TodoOptions>({
-		blurMode: false,
 		viewMode: TodoViewType.Day,
 	})
 
@@ -58,7 +56,6 @@ export function TodoProvider({ children }: { children: React.ReactNode }) {
 				setTodoOptions(todoOptions)
 			} else {
 				setToStorage('todoOptions', {
-					blurMode: false,
 					viewMode: TodoViewType.Day,
 				})
 			}

--- a/src/index.css
+++ b/src/index.css
@@ -193,3 +193,14 @@ html.modal-isActive {
 html.modal-isActive::-webkit-scrollbar {
 	display: none !important;
 }
+
+.disabled-blur-mode {
+	filter: blur(0px);
+	transition: filter 300ms ease-in-out;
+}
+
+.blur-mode {
+	filter: blur(20px);
+	pointer-events: none;
+	transition: filter 300ms ease-in;
+}

--- a/src/layouts/navbar/navbar.layout.tsx
+++ b/src/layouts/navbar/navbar.layout.tsx
@@ -1,53 +1,56 @@
-import { type JSX, useEffect, useState } from 'react'
-import { TbApps } from 'react-icons/tb'
-import { VscSettings } from 'react-icons/vsc'
-import { getFromStorage, setToStorage } from '@/common/storage'
-import { listenEvent } from '@/common/utils/call-event'
-import Tooltip from '@/components/toolTip'
-import { useWidgetVisibility } from '@/context/widget-visibility.context'
-import { getConfigData } from '@/services/config-data/config_data-api'
-import { SettingModal } from '../setting/setting-modal'
-import { FriendsList } from './friends-list/friends'
-import { ProfileNav } from './profile/profile'
-import { SyncButton } from './sync/sync'
+import { getFromStorage, setToStorage } from "@/common/storage";
+import { listenEvent } from "@/common/utils/call-event";
+import Tooltip from "@/components/toolTip";
+import { useGeneralSetting } from "@/context/general-setting.context";
+import { useWidgetVisibility } from "@/context/widget-visibility.context";
+import { getConfigData } from "@/services/config-data/config_data-api";
+import { type JSX, useEffect, useState } from "react";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
+import { TbApps } from "react-icons/tb";
+import { VscSettings } from "react-icons/vsc";
+import { SettingModal } from "../setting/setting-modal";
+import { FriendsList } from "./friends-list/friends";
+import { ProfileNav } from "./profile/profile";
+import { SyncButton } from "./sync/sync";
 
 export interface PageLink {
-	name: string
-	to: string
+	name: string;
+	to: string;
 }
 
 export function NavbarLayout(): JSX.Element {
-	const [showSettings, setShowSettings] = useState(false)
-	const { openWidgetSettings } = useWidgetVisibility()
-	const [tab, setTab] = useState<string | null>(null)
+	const [showSettings, setShowSettings] = useState(false);
+	const { openWidgetSettings } = useWidgetVisibility();
+	const { blurMode, updateSetting } = useGeneralSetting();
+	const [tab, setTab] = useState<string | null>(null);
 
 	const [logoData, setLogoData] = useState<{
-		logoUrl: string | null
-		content: string | null
+		logoUrl: string | null;
+		content: string | null;
 	}>({
 		logoUrl: null,
 		content: '<h1 class="text-xl text-gray-100">ویجتی‌فای</h1>',
-	})
+	});
 
 	useEffect(() => {
 		const handleOpenSettings = (tab: any) => {
 			if (tab) {
-				setTab(tab)
+				setTab(tab);
 			}
-			setShowSettings(true)
-		}
+			setShowSettings(true);
+		};
 
 		const loadConfig = async () => {
 			try {
-				const storeData = await getFromStorage('configData')
+				const storeData = await getFromStorage("configData");
 				if (storeData) {
 					setLogoData({
 						content: storeData.logo?.content,
 						logoUrl: storeData.logo?.url,
-					})
+					});
 				}
 
-				const data = await getConfigData()
+				const data = await getConfigData();
 				if (data.logo) {
 					if (
 						(storeData?.logo && storeData.logo.id !== data.logo.id) ||
@@ -56,27 +59,32 @@ export function NavbarLayout(): JSX.Element {
 						setLogoData({
 							content: data.logo.content,
 							logoUrl: data.logo.url,
-						})
+						});
 
-						await setToStorage('configData', {
+						await setToStorage("configData", {
 							...storeData,
 							logo: {
 								id: data.logo.id,
 								content: data.logo.content,
 								url: data.logo.url,
 							},
-						})
+						});
 					}
 				}
 			} catch {}
-		}
+		};
 
-		const openSettingEvent = listenEvent('openSettings', handleOpenSettings)
-		loadConfig()
+		const openSettingEvent = listenEvent("openSettings", handleOpenSettings);
+		loadConfig();
 		return () => {
-			openSettingEvent()
-		}
-	}, [])
+			openSettingEvent();
+		};
+	}, []);
+
+	const handleBlurModeToggle = () => {
+		const newBlurMode = !blurMode;
+		updateSetting("blurMode", newBlurMode);
+	};
 
 	return (
 		<>
@@ -91,7 +99,7 @@ export function NavbarLayout(): JSX.Element {
 						{logoData.logoUrl && (
 							<img
 								src={logoData.logoUrl}
-								alt={logoData.content || 'ویجتی‌فای'}
+								alt={logoData.content || "ویجتی‌فای"}
 								className="w-6 h-6 rounded-full"
 							/>
 						)}
@@ -107,6 +115,14 @@ export function NavbarLayout(): JSX.Element {
 					</a>
 				</div>
 				<div className="flex items-center gap-1">
+					<Tooltip content={blurMode ? "نمایش" : "مخفی"}>
+						<div
+							className="flex items-center w-8 h-8 gap-2 px-2 overflow-hidden transition-all border cursor-pointer border-content rounded-xl bg-content backdrop-blur-sm hover:opacity-80"
+							onClick={handleBlurModeToggle}
+						>
+							{blurMode ? <FaEye size={12} /> : <FaEyeSlash size={12} />}
+						</div>
+					</Tooltip>
 					<FriendsList />
 					<ProfileNav />
 					<SyncButton />
@@ -134,5 +150,5 @@ export function NavbarLayout(): JSX.Element {
 				selectedTab={tab}
 			/>
 		</>
-	)
+	);
 }

--- a/src/layouts/widgetify-card/widgetify.layout.tsx
+++ b/src/layouts/widgetify-card/widgetify.layout.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react'
 import { useAuth } from '@/context/auth.context'
+import { useGeneralSetting } from '@/context/general-setting.context'
+import { useEffect, useState } from 'react'
 import { WidgetContainer } from '../widgets/widget-container'
 import { NotificationCenter } from './notification-center/notification-center'
 import { GoogleOverviewCard } from './overviewCards/google.overviewCard'
@@ -9,6 +10,7 @@ import { PetProvider } from './pets/pet.context'
 
 export const WidgetifyLayout = () => {
 	const { user, isAuthenticated } = useAuth()
+	const { blurMode } = useGeneralSetting()
 
 	const [userName, setUserName] = useState<string>('')
 
@@ -27,10 +29,10 @@ export const WidgetifyLayout = () => {
 					</PetProvider>
 				}
 
-				<div className="relative z-10 flex flex-col items-center gap-1 overflow-y-auto h-60 small-scrollbar">
+				<div className="relative z-10 flex flex-col items-center gap-2 overflow-y-auto h-60 small-scrollbar">
 					<div
 						className={
-							'flex items-center w-full pb-1 border-b border-content'
+							'flex items-center w-full'
 						}
 					>
 						<div className="flex items-center gap-2">
@@ -41,7 +43,7 @@ export const WidgetifyLayout = () => {
 					</div>
 
 					{/* Daily Summary Content */}
-					<div className="flex flex-col flex-1 w-full gap-1 overflow-y-auto small-scrollbar">
+					<div className={`flex flex-col flex-1 w-full gap-1 overflow-y-auto small-scrollbar ${blurMode ? 'blur-mode' : 'disabled-blur-mode'}`}>
 						<TodoOverviewCard />
 						<GoogleOverviewCard />
 						<NotificationCenter />

--- a/src/layouts/widgets/notes/notes.layout.tsx
+++ b/src/layouts/widgets/notes/notes.layout.tsx
@@ -1,4 +1,5 @@
 import { RequireAuth } from '@/components/auth/require-auth'
+import { useGeneralSetting } from '@/context/general-setting.context'
 import { NotesProvider, useNotes } from '@/context/notes.context'
 import { FiBook, FiLoader } from 'react-icons/fi'
 import { WidgetContainer } from '../widget-container'
@@ -7,12 +8,13 @@ import { NoteNavigation } from './components/note-navigation'
 
 function NotesContent() {
 	const { notes, activeNoteId, addNote, updateNote } = useNotes()
+	const { blurMode } = useGeneralSetting()
 
 	const activeNote = notes.find((note) => note.id === activeNoteId)
 
 	if (!activeNote) {
 		return (
-			<div className="flex flex-col items-center justify-center h-full">
+			<div className={`flex flex-col items-center justify-center h-full ${blurMode ? 'blur-mode' : 'disabled-blur-mode'}`}>
 				<FiBook className={'w-8 h-8 mb-2 text-content opacity-50'} />
 				<p className={'text-sm text-muted'}>هیچ یادداشتی پیدا نشد</p>
 				<button
@@ -27,7 +29,7 @@ function NotesContent() {
 
 	return (
 		<>
-			<div className="mt-2 flex-grow overflow-auto h-[calc(100%-40px)]">
+			<div className={`mt-2 flex-grow overflow-auto h-[calc(100%-40px)] ${blurMode ? 'blur-mode' : 'disabled-blur-mode'}`}>
 				<div key={activeNoteId} className="h-full">
 					<NoteEditor note={activeNote} onUpdateNote={updateNote} />
 				</div>

--- a/src/layouts/widgets/todos/todos.tsx
+++ b/src/layouts/widgets/todos/todos.tsx
@@ -1,29 +1,27 @@
 import { Button } from '@/components/button/button'
 import { useDate } from '@/context/date.context'
+import { useGeneralSetting } from '@/context/general-setting.context'
 import { type AddTodoInput, TodoViewType, useTodoStore } from '@/context/todo.context'
 import { useState } from 'react'
 import { FaEye, FaEyeSlash } from 'react-icons/fa'
 import { FaChartSimple } from 'react-icons/fa6'
+import { FiList } from 'react-icons/fi'
 import { formatDateStr } from '../calendar/utils'
 import { WidgetContainer } from '../widget-container'
 import { ExpandableTodoInput } from './expandable-todo-input'
 import { TodoStats } from './todo-stats'
 import { TodoItem } from './todo.item'
-import { FiList } from 'react-icons/fi'
+
 export function TodosLayout() {
 	const { selectedDate, isToday } = useDate()
 	const { addTodo, todos, removeTodo, toggleTodo, updateOptions, todoOptions } =
 		useTodoStore()
+	const { blurMode,updateSetting } = useGeneralSetting()
 	const [filter, setFilter] = useState<'all' | 'active' | 'completed'>('all')
 
 	const [showStats, setShowStats] = useState<boolean>(false)
 	const [todoText, setTodoText] = useState('')
 	const selectedDateStr = formatDateStr(selectedDate.clone())
-
-	const handleBlurModeToggle = () => {
-		const newBlurMode = !todoOptions.blurMode
-		updateOptions({ blurMode: newBlurMode })
-	}
 
 	const handleChangeViewMode = (viewMode: TodoViewType) => {
 		updateOptions({ viewMode })
@@ -59,8 +57,6 @@ export function TodosLayout() {
 		return { total, completed, percentage }
 	}
 
-	const stats = getCompletionStats()
-
 	return (
 		<WidgetContainer>
 			<div className="flex flex-col h-full">
@@ -88,17 +84,6 @@ export function TodosLayout() {
 								className={`h-7 w-7 text-xs font-medium rounded-[0.55rem] transition-colors border-none shadow-none ${showStats ? 'bg-primary text-white' : 'text-muted hover:bg-base-300'}`}
 							>
 								<FaChartSimple size={12} />
-							</Button>
-							<Button
-								onClick={handleBlurModeToggle}
-								size="xs"
-								className={`h-7 w-7 text-xs font-medium rounded-[0.55rem] transition-colors border-none shadow-none ${todoOptions.blurMode ? 'bg-primary text-white' : 'text-muted hover:bg-base-300'}`}
-							>
-								{todoOptions.blurMode ? (
-									<FaEye size={12} />
-								) : (
-									<FaEyeSlash size={12} />
-								)}
 							</Button>
 						</div>
 					</div>
@@ -166,7 +151,7 @@ export function TodosLayout() {
 				<div className="mt-0.5 flex-grow overflow-hidden">
 					{!showStats && (
 						<div
-							className={`space-y-1.5 overflow-y-auto h-full ${todoOptions.blurMode ? 'blur-mode' : ''}`}
+							className={`space-y-1.5 overflow-y-auto h-full ${blurMode ? 'blur-mode' : 'disabled-blur-mode'}`}
 						>
 							{selectedDateTodos.length > 0 ? (
 								<>
@@ -176,7 +161,7 @@ export function TodosLayout() {
 											todo={todo}
 											deleteTodo={removeTodo}
 											toggleTodo={toggleTodo}
-											blurMode={todoOptions.blurMode}
+											blurMode={blurMode}
 										/>
 									))}
 								</>
@@ -212,13 +197,6 @@ export function TodosLayout() {
 					/>
 				)}
 			</div>
-
-			<style>{`
-                .blur-mode {
-                    filter: blur(5px);
-                    pointer-events: none;
-                }
-            `}</style>
 		</WidgetContainer>
 	)
 }

--- a/src/layouts/widgets/wigiPad/info-panel/tabs/birthday/birthday-tab.tsx
+++ b/src/layouts/widgets/wigiPad/info-panel/tabs/birthday/birthday-tab.tsx
@@ -1,13 +1,18 @@
-import type { InfoPanelData } from '../../hooks/useInfoPanelData'
-import { BirthdayItem } from './birthday-item'
-import { LuGift } from 'react-icons/lu'
+import { useGeneralSetting } from "@/context/general-setting.context";
+import { LuGift } from "react-icons/lu";
+import type { InfoPanelData } from "../../hooks/useInfoPanelData";
+import { BirthdayItem } from "./birthday-item";
 
 interface Props {
-	birthdays: InfoPanelData['birthdays']
+	birthdays: InfoPanelData["birthdays"];
 }
 export function BirthdayTab({ birthdays }: Props) {
+	const { blurMode } = useGeneralSetting();
+
 	return (
-		<div className="space-y-2">
+		<div
+			className={`space-y-2 ${blurMode ? "blur-mode" : "disabled-blur-mode"}`}
+		>
 			{birthdays.length > 0 ? (
 				birthdays.map((birthday) => (
 					<BirthdayItem key={birthday.id} birthday={birthday} />
@@ -15,12 +20,12 @@ export function BirthdayTab({ birthdays }: Props) {
 			) : (
 				<div
 					className={
-						'flex-1 flex flex-col items-center justify-center gap-y-1.5 px-5 py-1'
+						"flex-1 flex flex-col items-center justify-center gap-y-1.5 px-5 py-1"
 					}
 				>
 					<div
 						className={
-							'flex items-center justify-center w-12 h-12 mx-auto rounded-full bg-base-300/70 border-base/70'
+							"flex items-center justify-center w-12 h-12 mx-auto rounded-full bg-base-300/70 border-base/70"
 						}
 					>
 						<LuGift className="text-content" size={24} />
@@ -29,5 +34,5 @@ export function BirthdayTab({ birthdays }: Props) {
 				</div>
 			)}
 		</div>
-	)
+	);
 }

--- a/src/layouts/widgets/wigiPad/info-panel/tabs/google/google.tab.tsx
+++ b/src/layouts/widgets/wigiPad/info-panel/tabs/google/google.tab.tsx
@@ -1,37 +1,42 @@
-import { useAuth } from '@/context/auth.context'
-import { useDate } from '@/context/date.context'
-import { useGetGoogleCalendarEvents } from '@/services/hooks/date/getGoogleCalendarEvents.hook'
-import { LuLockKeyhole } from 'react-icons/lu'
-import { MdEvent } from 'react-icons/md'
-import { GoogleMeetingItem } from './google-meeting-item'
+import { useAuth } from "@/context/auth.context";
+import { useDate } from "@/context/date.context";
+import { useGeneralSetting } from "@/context/general-setting.context";
+import { useGetGoogleCalendarEvents } from "@/services/hooks/date/getGoogleCalendarEvents.hook";
+import { LuLockKeyhole } from "react-icons/lu";
+import { MdEvent } from "react-icons/md";
+import { GoogleMeetingItem } from "./google-meeting-item";
+
+const LoadingSkeleton = () => (
+	<div className="space-y-2">
+		{[...Array(3)].map((_, index) => (
+			<div key={index} className="p-2 rounded-lg bg-content animate-pulse">
+				<div className="flex items-center gap-3">
+					<div className="w-5 h-5 bg-gray-300 rounded"></div>
+					<div className="flex-1 space-y-2">
+						<div className="w-3/4 h-4 bg-gray-300 rounded"></div>
+						<div className="w-1/2 h-3 bg-gray-300 rounded"></div>
+						<div className="w-2/3 h-3 bg-gray-300 rounded"></div>
+					</div>
+				</div>
+			</div>
+		))}
+	</div>
+);
 
 export function GoogleTab() {
-	const { today } = useDate()
-	const { isAuthenticated } = useAuth()
+	const { today } = useDate();
+	const { isAuthenticated } = useAuth();
+	const { blurMode } = useGeneralSetting();
 	const { data: googleEvents, isLoading } = useGetGoogleCalendarEvents(
 		isAuthenticated,
 		today.clone().toDate(),
-		today.clone().add(30, 'day').toDate()
-	)
-	const LoadingSkeleton = () => (
-		<div className="space-y-2">
-			{[...Array(3)].map((_, index) => (
-				<div key={index} className="p-2 rounded-lg bg-content animate-pulse">
-					<div className="flex items-center gap-3">
-						<div className="w-5 h-5 bg-gray-300 rounded"></div>
-						<div className="flex-1 space-y-2">
-							<div className="w-3/4 h-4 bg-gray-300 rounded"></div>
-							<div className="w-1/2 h-3 bg-gray-300 rounded"></div>
-							<div className="w-2/3 h-3 bg-gray-300 rounded"></div>
-						</div>
-					</div>
-				</div>
-			))}
-		</div>
-	)
+		today.clone().add(30, "day").toDate(),
+	);
 
 	const GoogleEventsContent = () => (
-		<div className="space-y-2">
+		<div
+			className={`space-y-2 ${blurMode ? "blur-mode" : "disabled-blur-mode"}`}
+		>
 			{!isAuthenticated ? (
 				<div className="flex flex-col items-center py-1.5 text-center text-muted">
 					<LuLockKeyhole className="mb-2 text-3xl" />
@@ -48,12 +53,12 @@ export function GoogleTab() {
 			) : (
 				<div
 					className={
-						'flex-1 flex flex-col items-center justify-center gap-y-1.5 px-5 py-1'
+						"flex-1 flex flex-col items-center justify-center gap-y-1.5 px-5 py-1"
 					}
 				>
 					<div
 						className={
-							'flex items-center justify-center w-12 h-12 mx-auto rounded-full bg-base-300/70 border-base/70'
+							"flex items-center justify-center w-12 h-12 mx-auto rounded-full bg-base-300/70 border-base/70"
 						}
 					>
 						<MdEvent className="text-content" size={24} />
@@ -64,7 +69,7 @@ export function GoogleTab() {
 				</div>
 			)}
 		</div>
-	)
+	);
 
-	return <GoogleEventsContent />
+	return <GoogleEventsContent />;
 }


### PR DESCRIPTION
## In this PR
- the general hide mode added to navbar so user can hide the sensitive content using one button.
- the widgets this mode added to them: widgetify, notes, todos ( existed before locally ), birthdays, google calendar.

## Screenshots
<img width="1452" height="758" alt="Screenshot 1404-05-14 at 16 40 16" src="https://github.com/user-attachments/assets/903b4454-c4fd-427b-9bd0-2fe391191864" />
<img width="1457" height="758" alt="Screenshot 1404-05-14 at 16 40 08" src="https://github.com/user-attachments/assets/cfdb5595-af85-4ce0-b227-3d9b93ef70fa" />
<img width="1446" height="758" alt="Screenshot 1404-05-14 at 16 39 26" src="https://github.com/user-attachments/assets/262436dc-7039-49f4-9852-ebff62da250c" />



