### PR TITLE
refactor: simplify pomodoro timer color handling

### DIFF
--- a/src/layouts/widgets/tools/pomodoro/components/timer-display.tsx
+++ b/src/layouts/widgets/tools/pomodoro/components/timer-display.tsx
@@ -2,11 +2,16 @@ import type React from 'react'
 import { modeFullLabels } from '../constants'
 import type { TimerMode } from '../types'
 
+export const modeColors = {
+	work: 'stroke-primary',
+	'short-break': 'stroke-success',
+	'long-break': 'stroke-warning',
+}
+
 interface TimerDisplayProps {
 	timeLeft: number
 	progress: number
 	mode: TimerMode
-	getProgressColor: () => string
 	cycles: number
 	cyclesBeforeLongBreak: number
 }
@@ -15,7 +20,6 @@ export const TimerDisplay: React.FC<TimerDisplayProps> = ({
 	timeLeft,
 	progress,
 	mode,
-	getProgressColor,
 	cycles,
 	cyclesBeforeLongBreak,
 }) => {
@@ -42,12 +46,12 @@ export const TimerDisplay: React.FC<TimerDisplayProps> = ({
 					cy="50"
 					r="45"
 					fill="none"
-					stroke={getProgressColor()}
+					// stroke={getProgressColor()}
 					strokeWidth="5"
 					strokeDasharray="283"
 					strokeDashoffset={283 - (283 * progress) / 100}
 					transform="rotate(-90 50 50)"
-					className="transition-all duration-500 ease-out"
+					className={`transition-all duration-500 ease-out ${modeColors[mode]}`}
 				/>
 				{/* Timer text */}
 				<text

--- a/src/layouts/widgets/tools/pomodoro/constants.ts
+++ b/src/layouts/widgets/tools/pomodoro/constants.ts
@@ -1,11 +1,5 @@
 import type { TimerMode } from './types'
 
-export const modeColors = {
-	work: 'rgb(96, 165, 250)',
-	'short-break': 'rgb(74, 222, 128)',
-	'long-break': 'rgb(168, 85, 247)',
-}
-
 export const modeLabels: Record<TimerMode, string> = {
 	work: 'کار',
 	'short-break': 'کوتاه',

--- a/src/layouts/widgets/tools/pomodoro/pomodoro-timer.tsx
+++ b/src/layouts/widgets/tools/pomodoro/pomodoro-timer.tsx
@@ -11,7 +11,7 @@ import { ModeButton } from './components/mode-button'
 import { RequestNotificationModal } from './components/requestNotification-modal'
 import { PomodoroSettingsPanel } from './components/settings-panel'
 import { TimerDisplay } from './components/timer-display'
-import { modeColors } from './constants'
+
 import { TopUsersTab } from './topUsers/top-users'
 import type { PomodoroSettings, TimerMode } from './types'
 
@@ -291,9 +291,6 @@ export const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ onComplete }) => {
 		setToStorage('pomodoro_settings', newSettings)
 	}
 
-	const getProgressColor = () => {
-		return modeColors[mode]
-	}
 	return (
 		<div className="relative p-1 overflow-hidden duration-300 rounded-xl animate-in fade-in-0 slide-in-from-bottom-24">
 			{/* Mode Selection */}
@@ -342,7 +339,6 @@ export const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ onComplete }) => {
 						timeLeft={timeLeft}
 						progress={progress}
 						mode={mode}
-						getProgressColor={getProgressColor}
 						cycles={cycles}
 						cyclesBeforeLongBreak={settings.cyclesBeforeLongBreak}
 					/>


### PR DESCRIPTION
- Move mode colors to Tailwind classes in timer-display component
- Remove unnecessary getProgressColor function and prop
- Clean up color constants and