### PR TITLE
feat: remove long break feature from Pomodoro timer

### DIFF
--- a/src/layouts/widgets/tools/pomodoro/components/settings-panel.tsx
+++ b/src/layouts/widgets/tools/pomodoro/components/settings-panel.tsx
@@ -23,7 +23,7 @@ const SettingInput: React.FC<SettingInputProps> = ({ label, value, onChange, max
 					value={String(value)}
 					className="text-center"
 					onChange={(newValue) => {
-						const value = Number.parseInt(newValue)
+						const value = Number.parseInt(newValue, 10)
 						if (value > 0 && value <= max) {
 							onChange(value)
 						}
@@ -98,24 +98,6 @@ export const PomodoroSettingsPanel: React.FC<PomodoroSettingsPanelProps> = ({
 							handleSettingChange('shortBreakTime', value)
 						}}
 						max={30}
-					/>
-
-					<SettingInput
-						label="استراحت بلند:"
-						value={settings.longBreakTime}
-						onChange={(value) => {
-							handleSettingChange('longBreakTime', value)
-						}}
-						max={60}
-					/>
-
-					<SettingInput
-						label="تعداد دوره قبل از استراحت بلند:"
-						value={settings.cyclesBeforeLongBreak}
-						onChange={(value) => {
-							handleSettingChange('cyclesBeforeLongBreak', value)
-						}}
-						max={10}
 					/>
 				</div>
 				<div className="text-center">

--- a/src/layouts/widgets/tools/pomodoro/components/timer-display.tsx
+++ b/src/layouts/widgets/tools/pomodoro/components/timer-display.tsx
@@ -12,16 +12,12 @@ interface TimerDisplayProps {
 	timeLeft: number
 	progress: number
 	mode: TimerMode
-	cycles: number
-	cyclesBeforeLongBreak: number
 }
 
 export const TimerDisplay: React.FC<TimerDisplayProps> = ({
 	timeLeft,
 	progress,
 	mode,
-	cycles,
-	cyclesBeforeLongBreak,
 }) => {
 	const formatTime = (seconds: number) => {
 		const mins = Math.floor(seconds / 60)
@@ -29,9 +25,8 @@ export const TimerDisplay: React.FC<TimerDisplayProps> = ({
 		return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
 	}
 	return (
-		<div className="relative mx-auto mb-6 duration-300 w-36 h-36 animate-in zoom-in-95">
+		<div className="relative mx-auto mt-4 duration-300 w-36 h-36 animate-in zoom-in-95">
 			<svg className="w-full h-full" viewBox="0 0 100 100">
-				{/* Background circle */}
 				<circle
 					cx="50"
 					cy="50"
@@ -39,21 +34,30 @@ export const TimerDisplay: React.FC<TimerDisplayProps> = ({
 					fill="none"
 					stroke="#f3f4f6"
 					strokeWidth="5"
-				/>{' '}
-				{/* Progress circle with animation */}
+					filter="url(#shadow)"
+				/>
+				{/* Progress circle with gradient and smooth animation */}
 				<circle
 					cx="50"
 					cy="50"
 					r="45"
 					fill="none"
-					// stroke={getProgressColor()}
+					stroke="url(#progressGradient)"
 					strokeWidth="5"
 					strokeDasharray="283"
 					strokeDashoffset={283 - (283 * progress) / 100}
 					transform="rotate(-90 50 50)"
-					className={`transition-all duration-500 ease-out ${modeColors[mode]}`}
+					className={`transition-all duration-1000 ease-out ${modeColors[mode]}`}
+					strokeLinecap="round"
 				/>
-				{/* Timer text */}
+				<circle
+					cx="50"
+					cy="50"
+					r="40"
+					fill="none"
+					stroke="#ffffff10"
+					strokeWidth="1"
+				/>
 				<text
 					x="50"
 					y="50"
@@ -71,19 +75,6 @@ export const TimerDisplay: React.FC<TimerDisplayProps> = ({
 					{modeFullLabels[mode]}
 				</text>
 			</svg>{' '}
-			{/* Cycle indicator */}
-			<div className="flex justify-center mt-2 gap-x-1">
-				{Array.from({ length: cyclesBeforeLongBreak }).map((_, i) => (
-					<div
-						key={i}
-						className={`w-2 h-2 rounded-full transition-all duration-300 ${
-							i < cycles % cyclesBeforeLongBreak
-								? 'bg-blue-500 scale-100'
-								: 'bg-gray-700 scale-75'
-						}`}
-					/>
-				))}
-			</div>
 		</div>
 	)
 }

--- a/src/layouts/widgets/tools/pomodoro/constants.ts
+++ b/src/layouts/widgets/tools/pomodoro/constants.ts
@@ -3,11 +3,9 @@ import type { TimerMode } from './types'
 export const modeLabels: Record<TimerMode, string> = {
 	work: 'کار',
 	'short-break': 'کوتاه',
-	'long-break': 'بلند',
 }
 
 export const modeFullLabels: Record<TimerMode, string> = {
 	work: 'زمان کار',
 	'short-break': 'استراحت کوتاه',
-	'long-break': 'استراحت بلند',
 }

--- a/src/layouts/widgets/tools/pomodoro/topUsers/top-user-item.tsx
+++ b/src/layouts/widgets/tools/pomodoro/topUsers/top-user-item.tsx
@@ -25,6 +25,16 @@ export function TopUserItem({
 
 	const rank = index + 1
 	const style = rank <= 3 ? 'bg-success/10 text-success' : 'bg-primary/10 text-primary'
+
+	const convertToHours = (duration: number) => {
+		const hours = Math.floor(duration / 60)
+		const minutes = duration % 60
+		return `${hours} ساعت و ${minutes} دقیقه`
+	}
+
+	const duration: string =
+		user.duration > 500 ? convertToHours(user.duration) : `${user.duration} دقیقه`
+
 	return (
 		<>
 			<div
@@ -42,7 +52,7 @@ export function TopUserItem({
 					<p className="text-sm font-medium truncate text-content">
 						{user.name}
 					</p>
-					<p className="text-xs text-muted">{user.duration} دقیقه تمرکز</p>
+					<p className="text-xs text-muted">{duration}</p>
 				</div>
 
 				<div

--- a/src/layouts/widgets/tools/pomodoro/topUsers/top-user-item.tsx
+++ b/src/layouts/widgets/tools/pomodoro/topUsers/top-user-item.tsx
@@ -38,7 +38,7 @@ export function TopUserItem({
 	return (
 		<>
 			<div
-				className="relative flex items-center gap-3 p-2 transition-all cursor-pointer rounded-2xl bg-content hover:scale-95"
+				className="relative flex items-center gap-2 p-2 transition-all cursor-pointer rounded-2xl bg-content hover:scale-95"
 				onClick={() => setActiveProfileId(user.id)}
 				ref={containerRef}
 			>

--- a/src/layouts/widgets/tools/pomodoro/types.ts
+++ b/src/layouts/widgets/tools/pomodoro/types.ts
@@ -1,4 +1,4 @@
-export type TimerMode = 'work' | 'short-break' | 'long-break'
+export type TimerMode = 'work' | 'short-break'
 
 export interface PomodoroSettings {
 	workTime: number
@@ -21,4 +21,3 @@ export interface PomodoroSession {
 	cycles: number
 	isRunning: boolean
 }
-


### PR DESCRIPTION
- Eliminated long break mode, settings, and cycle indicators
- Simplified timer logic to work and short-break only
- Updated UI components and types accordingly
- Added duration formatting for top users (hours/minutes if >500 min)