### PR TITLE
fix: enhance FolderPath component with current folder indication and …

### DIFF
--- a/src/layouts/bookmark/bookmarks.tsx
+++ b/src/layouts/bookmark/bookmarks.tsx
@@ -337,11 +337,15 @@ export function BookmarksComponent() {
 							)
 						)}
 					</SortableContext>
+					<div className="flex justify-center col-span-5 w-full mt-0.5 min-h-8">
+						<FolderPath
+							folderPath={folderPath}
+							onNavigate={handleNavigate}
+							currentFolderId={currentFolderId}
+						/>
+					</div>
 				</div>
 			</DndContext>
-			<div className="flex justify-center w-full mt-0.5">
-				<FolderPath folderPath={folderPath} onNavigate={handleNavigate} />
-			</div>
 			<AddBookmarkModal
 				isOpen={showAddBookmarkModal}
 				onClose={() => setShowAddBookmarkModal(false)}

--- a/src/layouts/bookmark/components/folder-path.tsx
+++ b/src/layouts/bookmark/components/folder-path.tsx
@@ -1,30 +1,36 @@
 import type { FolderPathItem } from '../types/bookmark.types'
+import { TbHomeRibbon } from 'react-icons/tb'
 
 type FolderPathProps = {
 	folderPath: FolderPathItem[]
 	onNavigate: (folderId: string | null, depth: number) => void
-}
+	currentFolderId?: FolderPathItem["id"] | null
+};
 
-export function FolderPath({ folderPath, onNavigate }: FolderPathProps) {
+export function FolderPath({
+	folderPath,
+	onNavigate,
+	currentFolderId = null,
+}: FolderPathProps) {
 	if (folderPath.length === 0) return null
 
 	return (
 		<nav
 			aria-label="Folder navigation"
 			className={
-				'flex w-fit items-center px-4 py-2 text-xs rounded-full bg-widget bg-glass'
+				"flex w-fit items-center px-4 py-2 text-xs leading-3 rounded-xl bg-widget bg-glass"
 			}
 		>
 			<ol className="flex flex-wrap items-center gap-y-1">
-				<li>
+				<li className="leading-0">
 					<button
 						onClick={() => onNavigate(null, -1)}
 						className={
-							'cursor-pointer transition-colors text-content opacity-70 hover:opacity-100'
+							"cursor-pointer transition-colors text-content opacity-70 hover:opacity-100"
 						}
 						aria-label="Go to root folder"
 					>
-						بازگشت
+						<TbHomeRibbon className="size-4 text-muted" />
 					</button>
 				</li>
 
@@ -41,18 +47,28 @@ export function FolderPath({ folderPath, onNavigate }: FolderPathProps) {
 								strokeLinecap="round"
 								strokeLinejoin="round"
 								strokeWidth={2}
-								d="M9 5l7 7-7 7"
+								d="M16 5L9 12L16 19"
 							/>
 						</svg>
-						<button
-							onClick={() => onNavigate(item.id, index)}
-							className={
-								'cursor-pointer transition-colors text-blue-400 hover:text-blue-300'
-							}
-							aria-label={`Go to ${item.title} folder`}
-						>
-							{item.title}
-						</button>
+
+						{item.id === currentFolderId ? (
+							<span
+								className="cursor-default transition-colors text-content font-bold"
+								aria-label={`Current folder (${item.title})`}
+							>
+								{item.title}
+							</span>
+						) : (
+							<button
+								onClick={() => onNavigate(item.id, index)}
+								className={
+									"cursor-pointer transition-colors opacity-70 hover:opacity-100"
+								}
+								aria-label={`Go to ${item.title} folder`}
+							>
+								{item.title}
+							</button>
+						)}
 					</li>
 				))}
 			</ol>


### PR DESCRIPTION
منوی پوشه های بوکمارک الان به این صورت هستن:
<img width="189" height="37" alt="Screenshot 2025-09-21 094927" src="https://github.com/user-attachments/assets/47f97b63-5df7-457b-8067-7f0dc3d7fcbc" />
1- آیکن مربوط به زیرشاخه ها بصورت برعکس نمایش داده میشن
2- کلمه بازگشت به آدم این رو نشون میده که به یک پوشه بالاتر میره در صورتی که با کلیک روی اون به روت بوکمارکها هدایت میشیم
3- پوشه فعلی قابل کلیک کردن هست
4- با اینکه هم دکمه رفتن به روت و هم زیر شاخه پوشه ها قابل کلیک کردن هستن ولی رنگشون متفاوته
5- وقتی وارد اولین پوشه میشیم بخاطر ظاهر شدن منو ویجتهای پایین جامپ میکنن به پایین تر
تغییرات پیشنهادی من:
1- برعکس کردن آیکن زیرشاخه ها به سمت چپ
2- بجای کلمه بازگشت استفاده از آیکن برای نشان دادن رفتن به روت
3- تشخیص پوشه فعلی و حذف کلیک کردن و نمایش بصورت بولد
4- نمایش همه دکمه ها با یک رنگ
5- در نظر گرفتن حداقل فضای لازم در زیر بوکمارکها برای نمایش منو و جلوگیری از جامپ ویجتها
<img width="247" height="57" alt="Screenshot 2025-09-21 094937" src="https://github.com/user-attachments/assets/2d18ac8e-8212-413b-8b45-b5fe49e501cc" />
