### PR TITLE
feat: add disabled, soon, and popular states to widget visibility man…

### DIFF
--- a/src/context/widget-visibility.context.tsx
+++ b/src/context/widget-visibility.context.tsx
@@ -43,6 +43,9 @@ export interface WidgetItem {
 	order: number
 	canToggle?: boolean
 	isNew?: boolean
+	disabled?: boolean
+	soon?: boolean
+	popular?: boolean
 }
 
 export const widgetItems: WidgetItem[] = [
@@ -53,6 +56,7 @@ export const widgetItems: WidgetItem[] = [
 		order: 0,
 		node: <CalendarLayout />,
 		canToggle: true,
+		popular: true,
 	},
 	{
 		id: WidgetKeys.tools,
@@ -89,6 +93,7 @@ export const widgetItems: WidgetItem[] = [
 			</CurrencyProvider>
 		),
 		canToggle: true,
+		popular: true,
 	},
 	{
 		id: WidgetKeys.arzLive,
@@ -125,7 +130,9 @@ export const widgetItems: WidgetItem[] = [
 		label: 'آمار یوتیوب',
 		order: 8,
 		node: <YouTubeLayout />,
-		canToggle: true,
+		canToggle: false,
+		disabled: true,
+		soon: true,
 	},
 	{
 		id: WidgetKeys.network,

--- a/src/pages/home/content-section.tsx
+++ b/src/pages/home/content-section.tsx
@@ -78,7 +78,7 @@ function SortableWidget({ widget }: { widget: WidgetItem }) {
 export function ContentSection() {
 	const { contentAlignment } = useAppearanceSetting()
 	const { getSortedWidgets, reorderWidgets } = useWidgetVisibility()
-	const sortedWidgets = getSortedWidgets()
+	const sortedWidgets = getSortedWidgets().filter((widget) => !widget.disabled)
 
 	const totalWidgetCount = sortedWidgets.length
 


### PR DESCRIPTION
<img width="615" height="363" alt="image" src="https://github.com/user-attachments/assets/5c6198f6-9854-4079-8151-c628d7abad2d" />

- Add disabled, soon, and popular properties to WidgetItem interface
- Update widget items with new states (e.g., YouTube as disabled/soon, Calendar/Currency as popular)
- Refactor ManageWidgets component to handle new states with visual indicators
- Filter out disabled/soon widgets from home content section