### PR TITLE
refactor(pets): remove the pet visibility toggle

### DIFF
--- a/src/common/constant/store.key.ts
+++ b/src/common/constant/store.key.ts
@@ -81,7 +81,6 @@ export interface StorageKV {
 		name: string
 	}
 	pendingOrders: any
-	petState: boolean
 	showNewBadgeForReOrderWidgets: boolean
 	navbarVisible: boolean
 	todoFilter: string

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -58,6 +58,14 @@ export async function removeFromStorage<K extends keyof StorageKV>(key: K) {
 	await storage.removeItem(`local:${key}`)
 }
 
+export const DEPRECATED_STORAGE_KEYS = ['petState'] as const
+
+export async function purgeDeprecatedStorageKeys() {
+	await Promise.all(
+		DEPRECATED_STORAGE_KEYS.map((key) => storage.removeItem(`local:${key}`))
+	)
+}
+
 export function watchStorage<K extends keyof StorageKV>(
 	key: K,
 	callback: (newValue: StorageKV[K] | null, oldValue: StorageKV[K] | null) => void

--- a/src/common/utils/call-event.ts
+++ b/src/common/utils/call-event.ts
@@ -38,7 +38,6 @@ export interface EventName {
 		petName?: string
 		petType: PetTypes
 	}
-	updatedPetState: boolean
 	theme_change: {
 		theme: string
 		sync: boolean

--- a/src/layouts/widgetify-card/pets/README.md
+++ b/src/layouts/widgetify-card/pets/README.md
@@ -40,7 +40,6 @@ export enum PetTypes {
 
 ```tsx
 const DEFAULT_SETTINGS: PetSettings = {
-  enablePets: true,
   petType: null,
   petOptions: {
     [PetTypes.DOG_AKITA]: {

--- a/src/layouts/widgetify-card/pets/pet.context.tsx
+++ b/src/layouts/widgetify-card/pets/pet.context.tsx
@@ -34,8 +34,6 @@ interface PetSettingsContextType extends PetSettings {
 		level: number
 		lastHungerTick: number | null
 	} | null
-	isEnabled: boolean
-	setIsEnabled: (value: boolean) => void
 }
 export const BASE_PET_OPTIONS: PetSettings = {
 	petType: PetTypes.DOG_AKITA,
@@ -94,15 +92,10 @@ export function PetProvider({ children }: { children: React.ReactNode }) {
 	const [settings, setSettings] = useState<PetSettings>({
 		...BASE_PET_OPTIONS,
 	})
-	const [isEnabled, setIsEnabled] = useState(false)
-
 	useEffect(() => {
 		async function load() {
 			// const storedPets = await getFromStorage('pets')
-			const [storedPets, petState] = await Promise.all([
-				getFromStorage('pets'),
-				getFromStorage('petState'),
-			])
+			const storedPets = await getFromStorage('pets')
 			if (storedPets) {
 				if (!storedPets.petOptions['dog-akita'].hungryState) {
 					setToStorage('pets', {
@@ -128,12 +121,6 @@ export function PetProvider({ children }: { children: React.ReactNode }) {
 				}
 				setSettings(initialSettings)
 				await setToStorage('pets', initialSettings)
-			}
-
-			if (typeof petState === 'boolean') {
-				setIsEnabled(petState)
-			} else {
-				setIsEnabled(true)
 			}
 		}
 
@@ -171,14 +158,8 @@ export function PetProvider({ children }: { children: React.ReactNode }) {
 			}
 		})
 
-		const event2 = listenEvent('updatedPetState', (data) => {
-			setIsEnabled(data)
-			setToStorage('petState', data)
-		})
-
 		return () => {
 			event()
-			event2()
 		}
 	}, [])
 
@@ -259,13 +240,11 @@ export function PetProvider({ children }: { children: React.ReactNode }) {
 
 	const contextValue: PetSettingsContextType = {
 		...settings,
-		isEnabled,
 		getCurrentPetName,
 		levelUpHungryState,
 		isPetHungry,
 		levelDownHungryState,
 		getPetHungryState,
-		setIsEnabled,
 	}
 
 	return <PetContext.Provider value={contextValue}>{children}</PetContext.Provider>

--- a/src/layouts/widgetify-card/pets/pet.tsx
+++ b/src/layouts/widgetify-card/pets/pet.tsx
@@ -1,12 +1,10 @@
-import { usePetContext } from './pet.context'
 import { PetFactory } from './pet-factory'
 import { useGeneralSetting } from '@/context/general-setting.context'
 
 export function Pet() {
 	const { isOptimalMode } = useGeneralSetting()
-	const { isEnabled } = usePetContext()
 
-	if (!isEnabled || isOptimalMode) return null
+	if (isOptimalMode) return null
 
 	return <PetFactory />
 }

--- a/src/layouts/widgetify-card/pets/setting/pet-setting.tsx
+++ b/src/layouts/widgetify-card/pets/setting/pet-setting.tsx
@@ -3,7 +3,6 @@ import { getFromStorage } from '@/common/storage'
 import { callEvent } from '@/common/utils/call-event'
 import { ItemSelector } from '@/components/ui'
 import { TextInput } from '@/components/text-input'
-import { ToggleSwitch } from '@/components/ui'
 import { BASE_PET_OPTIONS, PetTypes } from '@/layouts/widgetify-card/pets/pet.context'
 const persianType: Record<string, string> = {
 	dog: 'سگ',
@@ -11,35 +10,21 @@ const persianType: Record<string, string> = {
 	crab: 'خرچنگ',
 }
 export function PetSettings() {
-	const [enablePets, setEnablePets] = useState(true)
 	const [petType, setPetType] = useState<PetTypes>(PetTypes.DOG_AKITA)
 	const [petName, setPetName] = useState<string>('')
 
 	useEffect(() => {
 		async function load() {
-			const [storedPets, petState] = await Promise.all([
-				getFromStorage('pets'),
-				getFromStorage('petState'),
-			])
+			const storedPets = await getFromStorage('pets')
 			if (storedPets?.petOptions) {
 				const type = storedPets.petType || PetTypes.DOG_AKITA
 				setPetType(type)
 				setPetName(storedPets.petOptions[type].name)
 			}
-			if (typeof petState === 'boolean') {
-				setEnablePets(petState)
-			} else {
-				setEnablePets(true)
-			}
 		}
 
 		load()
 	}, [])
-
-	async function onChangeEnablePets(value: boolean) {
-		callEvent('updatedPetState', value)
-		setEnablePets(value)
-	}
 
 	async function onChangePetName(value: string) {
 		callEvent('updatedPetSettings', {
@@ -70,21 +55,7 @@ export function PetSettings() {
 
 	return (
 		<div className="flex flex-col w-full max-w-xl mx-auto">
-			<div className="flex items-center justify-between flex-1 gap-3">
-				<div className="overflow-hidden">
-					<span className={`block truncate`}>نمایش حیوان خانگی</span>
-					<span className={'block text-sm font-light text-muted'}>
-						نمایش حیوان خانگی تعاملی روی صفحه اصلی
-					</span>
-				</div>
-				<ToggleSwitch
-					enabled={enablePets}
-					disabled={false}
-					onToggle={() => onChangeEnablePets(!enablePets)}
-				/>
-			</div>
-
-			<div className={'p-2 mt-4 rounded-lg border border-content'}>
+			<div className={'p-2 rounded-lg border border-content'}>
 				<p className={'mb-3 font-medium text-content'}>نوع حیوان خانگی</p>
 				<div className="grid grid-cols-3 gap-1 mb-2">
 					{availablePets.map((pet) => (

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Toaster } from 'react-hot-toast'
 import Analytics from '@/analytics'
+import { purgeDeprecatedStorageKeys } from '@/common/storage'
 import { listenEvent } from '@/common/utils/call-event'
 import {
 	GeneralSettingProvider,
@@ -24,6 +25,10 @@ import { IconProvider } from '../icons/icons.context'
 
 export function RootLayout() {
 	useWallpaperApply()
+
+	useEffect(() => {
+		purgeDeprecatedStorageKeys()
+	}, [])
 
 	return (
 		<div className="w-full min-h-screen mx-auto md:px-4 lg:px-0 max-w-[1080px] flex flex-col h-screen overflow-y-auto scrollbar-none">


### PR DESCRIPTION
## Why

The pet settings tab had an on/off switch for showing the pet. It only affected the `Pet` component rendered inside the widgetify card: the pet **canvas widget** renders `PetFactory` directly and never read the flag. So the same setting behaved differently depending on where the pet appeared, and turning it off did nothing for anyone using the pet as a canvas widget.

Since the pet is now a widget you add or remove from the canvas, a separate visibility toggle is redundant.

## What was removed

- The switch, its `enablePets` state and `onChangeEnablePets` handler in the pet settings tab
- `isEnabled` / `setIsEnabled` from the pet context type and value, the `updatedPetState` listener, and the `petState` read and write
- The `isEnabled` condition in the `Pet` render guard, leaving only `isOptimalMode`
- The `updatedPetState` event and the `petState` storage key
- The stale `enablePets` entry in the pets README

The pet now behaves the same in both places.

## Storage cleanup

Adds `purgeDeprecatedStorageKeys`, called once on startup, so the orphaned `petState` value is cleared from existing installs instead of lingering unused. New deprecated keys can be added to the same list later.

## User visible change

Anyone who had previously switched the pet off in the widgetify card will see it again, since the flag is no longer read.

## Testing

`npm test` (32 tests), `npm run compile`, `biome check` and `npm run build` all pass. No references to `petState`, `updatedPetState` or `enablePets` remain anywhere in `src`.
