### PR TITLE
fix(ui): give modals, dropdowns and popovers a real closing animation

### DIFF
--- a/src/common/utils/animation-timing.ts
+++ b/src/common/utils/animation-timing.ts
@@ -1,0 +1,5 @@
+export const EXIT_ANIMATION_MS = 360
+
+export function isRetainableValue(value: unknown): boolean {
+	return value !== null && value !== undefined && value !== false
+}

--- a/src/components/ui/bottom-sheet/bottom-sheet.tsx
+++ b/src/components/ui/bottom-sheet/bottom-sheet.tsx
@@ -50,86 +50,87 @@ export function BottomSheet({
 		<Portal>
 			<Presence>
 				{isOpen && (
-					<>
-						<motion.div
-							className={`fixed inset-0 z-50 ${isDragging ? '' : 'bg-black'}`}
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 0.5 }}
-							exit={{ opacity: 0 }}
-							transition={{ duration: 0.3, ease: 'easeOut' }}
-							onClick={closeOnBackdrop ? onClose : undefined}
-						/>
+					<motion.div
+						key="bottom-sheet-backdrop"
+						className={`fixed inset-0 z-50 ${isDragging ? '' : 'bg-black/50'}`}
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						transition={{ duration: 0.25, ease: 'easeOut' }}
+						onClick={closeOnBackdrop ? onClose : undefined}
+					/>
+				)}
 
-						<motion.div
-							className={`fixed left-0 right-0 ${isDragging ? 'z-10' : 'z-50'} bottom-16 min-w-2xl bg-base-200 bg-glass rounded-t-3xl`}
-							style={{
-								height: sizes[size],
-								maxWidth: '390px',
-								margin: '0 auto',
-								touchAction: 'none',
-							}}
-							initial={{ y: '100%' }}
-							animate={{ y: 0 }}
-							exit={{ y: '100%' }}
-							transition={{
-								type: 'spring',
-								damping: 30,
-								stiffness: 300,
-								mass: 0.8,
-							}}
-							drag="y"
-							dragConstraints={{ top: 0, bottom: 0 }}
-							dragElastic={{ top: 0, bottom: 0.5 }}
-							onDragStart={() => setIsDragging(true)}
-							onDragEnd={handleDragEnd}
-							dragMomentum={false}
-						>
-							<div className="flex justify-center pt-4 pb-1 cursor-grab active:cursor-grabbing">
-								<motion.div
-									className="rounded-full bg-base-content/10"
-									animate={{
-										width: isDragging ? 16 : 28,
-										scaleY: isDragging ? 0.7 : 1,
-									}}
-									transition={{ duration: 0.2 }}
-									style={{ height: '3px' }}
-								/>
-							</div>
-
-							{title && (
-								<div className="relative flex items-center justify-center px-6 py-2">
-									{showBack && (
-										<button
-											onClick={onClickBack}
-											className="absolute p-2 transition-all duration-200 rounded-full right-6 active:scale-95"
-											aria-label="بستن"
-										>
-											<Icon
-												name="chevronRight"
-												size={20}
-												className="text-base-content/60"
-											/>
-										</button>
-									)}
-									<h2 className="text-sm font-bold text-content">
-										{title}
-									</h2>
-								</div>
-							)}
-
-							<div
-								className="px-4 pt-2 pb-4 mt-1 overflow-y-auto scrollbar-none"
-								style={{
-									height: title
-										? `calc(${sizes[size]} - 44px)`
-										: `calc(${sizes[size]} - 30px)`,
-									WebkitOverflowScrolling: 'touch',
+				{isOpen && (
+					<motion.div
+						key="bottom-sheet-panel"
+						className={`fixed left-0 right-0 ${isDragging ? 'z-10' : 'z-50'} bottom-16 min-w-2xl bg-base-200 bg-glass rounded-t-3xl`}
+						style={{
+							height: sizes[size],
+							maxWidth: '390px',
+							margin: '0 auto',
+							touchAction: 'none',
+							willChange: 'transform',
+						}}
+						initial={{ y: '100%' }}
+						animate={{ y: 0 }}
+						exit={{ y: '100%', transition: { duration: 0.25, ease: 'easeIn' } }}
+						transition={{
+							type: 'spring',
+							damping: 30,
+							stiffness: 300,
+							mass: 0.8,
+						}}
+						drag="y"
+						dragConstraints={{ top: 0, bottom: 0 }}
+						dragElastic={{ top: 0, bottom: 0.5 }}
+						onDragStart={() => setIsDragging(true)}
+						onDragEnd={handleDragEnd}
+						dragMomentum={false}
+					>
+						<div className="flex justify-center pt-4 pb-1 cursor-grab active:cursor-grabbing">
+							<motion.div
+								className="rounded-full bg-base-content/10"
+								animate={{
+									scaleX: isDragging ? 0.57 : 1,
+									scaleY: isDragging ? 0.7 : 1,
 								}}
-							>
-								{children}
+								transition={{ duration: 0.2 }}
+								style={{ height: '3px', width: '28px' }}
+							/>
+						</div>
+
+						{title && (
+							<div className="relative flex items-center justify-center px-6 py-2">
+								{showBack && (
+									<button
+										onClick={onClickBack}
+										className="absolute p-2 transition-all duration-200 rounded-full right-6 active:scale-95"
+										aria-label="بستن"
+									>
+										<Icon
+											name="chevronRight"
+											size={20}
+											className="text-base-content/60"
+										/>
+									</button>
+								)}
+								<h2 className="text-sm font-bold text-content">{title}</h2>
 							</div>
-						</motion.div>
-					</>
+						)}
+
+						<div
+							className="px-4 pt-2 pb-4 mt-1 overflow-y-auto scrollbar-none"
+							style={{
+								height: title
+									? `calc(${sizes[size]} - 44px)`
+									: `calc(${sizes[size]} - 30px)`,
+								WebkitOverflowScrolling: 'touch',
+							}}
+						>
+							{children}
+						</div>
+					</motion.div>
 				)}
 			</Presence>
 		</Portal>

--- a/src/components/ui/dropdown/dropdown.tsx
+++ b/src/components/ui/dropdown/dropdown.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { Portal } from '../portal/portal'
 import { useDropdown } from './use-dropdown'
 import { useState, useLayoutEffect, useRef } from 'react'
+import { Motion, Presence } from '@/common/motion'
 
 export interface DropdownOption {
 	id: string
@@ -207,36 +208,46 @@ export function Dropdown({
 				{trigger}
 			</div>
 
-			{isOpen && !disabled && (
-				<Portal>
-					<div id={id} className="fixed inset-0 z-popover pointer-events-none">
+			<Portal>
+				<Presence>
+					{isOpen && !disabled && (
 						<div
-							ref={dropdownContentRef}
-							className={`fixed z-popover shadow-xl overflow-hidden rounded-2xl bg-transparent! transition-opacity duration-100 ${isReady ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'} bg-glass ${dropdownClassName}`}
-							style={{
-								maxHeight,
-								width:
-									width === 'auto'
-										? 'auto'
-										: width === 'full'
-											? '100%'
-											: width,
-								minWidth: width === 'auto' ? '150px' : undefined,
-								top: dropdownPosition.top,
-								left: dropdownPosition.left,
-								visibility: isReady ? 'visible' : 'hidden',
-							}}
+							key="dropdown-layer"
+							id={id}
+							className="fixed inset-0 z-popover pointer-events-none"
 						>
-							<div
-								className="overflow-y-auto overscroll-contain scrollbar-none"
-								style={{ maxHeight }}
+							<Motion.div
+								ref={dropdownContentRef}
+								className={`fixed z-popover shadow-xl overflow-hidden rounded-2xl bg-transparent! ${isReady ? 'pointer-events-auto' : 'pointer-events-none'} bg-glass ${dropdownClassName}`}
+								initial={{ opacity: 0, scale: 0.95 }}
+								animate={{ opacity: isReady ? 1 : 0, scale: isReady ? 1 : 0.95 }}
+								exit={{ opacity: 0, scale: 0.95 }}
+								transition={{ duration: 0.15, ease: 'easeOut' }}
+								style={{
+									maxHeight,
+									width:
+										width === 'auto'
+											? 'auto'
+											: width === 'full'
+												? '100%'
+												: width,
+									minWidth: width === 'auto' ? '150px' : undefined,
+									top: dropdownPosition.top,
+									left: dropdownPosition.left,
+									visibility: isReady ? 'visible' : 'hidden',
+								}}
 							>
-								{dropdownContent}
-							</div>
+								<div
+									className="overflow-y-auto overscroll-contain scrollbar-none"
+									style={{ maxHeight }}
+								>
+									{dropdownContent}
+								</div>
+							</Motion.div>
 						</div>
-					</div>
-				</Portal>
-			)}
+					)}
+				</Presence>
+			</Portal>
 		</div>
 	)
 }

--- a/src/components/ui/modal/modal.tsx
+++ b/src/components/ui/modal/modal.tsx
@@ -6,7 +6,7 @@ import { Icon } from '@/src/icons'
 import { useDelayedUnmount } from '@/hooks/use-delayed-unmount'
 import { modalBoxVariants, modalScrollVariants } from './modal.variants'
 
-const MODAL_EXIT_MS = 300
+export const MODAL_EXIT_MS = 360
 
 export type ModalProps = VariantProps<typeof modalBoxVariants> & {
 	isOpen: boolean

--- a/src/components/ui/modal/modal.tsx
+++ b/src/components/ui/modal/modal.tsx
@@ -1,9 +1,12 @@
 import type { VariantProps } from 'class-variance-authority'
-import React, { type ReactNode, useEffect, useRef } from 'react'
+import React, { type ReactNode, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { cn } from '@/common/utils/cn'
 import { Icon } from '@/src/icons'
+import { useDelayedUnmount } from '@/hooks/use-delayed-unmount'
 import { modalBoxVariants, modalScrollVariants } from './modal.variants'
+
+const MODAL_EXIT_MS = 300
 
 export type ModalProps = VariantProps<typeof modalBoxVariants> & {
 	isOpen: boolean
@@ -71,26 +74,31 @@ export function Modal({
 	}, [isOpen])
 
 	const modalBoxClasses = cn(modalBoxVariants({ size }), className)
+	const shouldRenderContent = useDelayedUnmount(isOpen, MODAL_EXIT_MS)
+	const [isMounted, setIsMounted] = useState(false)
 
-	if (!isOpen) return null
+	useEffect(() => {
+		const frame = requestAnimationFrame(() => setIsMounted(true))
+		return () => cancelAnimationFrame(frame)
+	}, [])
 
 	return createPortal(
 		<dialog
-			open={isOpen}
+			open={isOpen && isMounted}
 			dir={direction}
 			aria-labelledby={typeof title === 'string' ? title : 'modal-title'}
 			aria-modal="true"
 			onClick={() => closeOnBackdropClick && onClose()}
 			onContextMenu={(e) => e.stopPropagation()}
-			className="flex items-center justify-center p-2 transition-opacity duration-200 opacity-100 modal modal-middle md:p-4"
+			className="flex items-center justify-center p-2 modal modal-middle md:p-4"
 		>
 			<div
 				ref={modalRef}
 				onClick={(e) => e.stopPropagation()}
 				onContextMenu={(e) => e.stopPropagation()}
-				className={cn(modalBoxClasses, 'animate-modal-in')}
+				className={modalBoxClasses}
 			>
-				{(title || showCloseButton) && (
+				{shouldRenderContent && (title || showCloseButton) && (
 					<div className="flex items-center justify-between gap-2 mb-2 md:mb-3 md:gap-4">
 						{title && (
 							<h3
@@ -117,7 +125,9 @@ export function Modal({
 						)}
 					</div>
 				)}
-				<div className={modalScrollVariants({ size })}>{children}</div>
+				<div className={modalScrollVariants({ size })}>
+					{shouldRenderContent && children}
+				</div>
 			</div>
 		</dialog>,
 		document.body

--- a/src/components/ui/modal/modal.tsx
+++ b/src/components/ui/modal/modal.tsx
@@ -3,10 +3,10 @@ import React, { type ReactNode, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { cn } from '@/common/utils/cn'
 import { Icon } from '@/src/icons'
-import { useDelayedUnmount } from '@/hooks/use-delayed-unmount'
+import { EXIT_ANIMATION_MS, useDelayedUnmount } from '@/hooks/use-delayed-unmount'
 import { modalBoxVariants, modalScrollVariants } from './modal.variants'
 
-export const MODAL_EXIT_MS = 360
+export const MODAL_EXIT_MS = EXIT_ANIMATION_MS
 
 export type ModalProps = VariantProps<typeof modalBoxVariants> & {
 	isOpen: boolean

--- a/src/components/ui/modal/modal.variants.ts
+++ b/src/components/ui/modal/modal.variants.ts
@@ -8,8 +8,6 @@ export const modalBoxVariants = cva(
 		'p-3',
 		'md:p-4',
 		'elevation-lg',
-		'transition-all',
-		'duration-200',
 	],
 	{
 		variants: {

--- a/src/components/user/user-card-portal.tsx
+++ b/src/components/user/user-card-portal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { Motion, Presence } from '@/common/motion'
+import { Portal } from '@/components/ui'
 import { UserCard } from './user-card'
 
 export interface UserCardUser {
@@ -62,21 +63,28 @@ export function UserCardPortal({
 		}
 	}, [isOpen, onClose, triggerRef])
 
-	if (!isOpen) return null
-
-	return createPortal(
-		<div
-			ref={cardRef}
-			className="fixed z-popover shadow-lg min-w-64 max-w-64"
-			style={{
-				top: `${position.top}px`,
-				left: `${position.left}px`,
-				transform: 'translateX(-50%)',
-			}}
-			dir="ltr"
-		>
-			<UserCard user={user} />
-		</div>,
-		document.body
+	return (
+		<Portal>
+			<Presence>
+				{isOpen && (
+					<Motion.div
+						key="user-card"
+						ref={cardRef}
+						className="fixed z-popover shadow-lg min-w-64 max-w-64"
+						initial={{ opacity: 0, scale: 0.95, x: '-50%' }}
+						animate={{ opacity: 1, scale: 1, x: '-50%' }}
+						exit={{ opacity: 0, scale: 0.95, x: '-50%' }}
+						transition={{ duration: 0.15, ease: 'easeOut' }}
+						style={{
+							top: `${position.top}px`,
+							left: `${position.left}px`,
+						}}
+						dir="ltr"
+					>
+						<UserCard user={user} />
+					</Motion.div>
+				)}
+			</Presence>
+		</Portal>
 	)
 }

--- a/src/context/general-setting.context.tsx
+++ b/src/context/general-setting.context.tsx
@@ -77,6 +77,12 @@ export function GeneralSettingProvider({ children }: { children: React.ReactNode
 	}, [])
 
 	useEffect(() => {
+		const root = document.documentElement
+		root.classList.toggle('optimal-mode', Boolean(settings.isOptimalMode))
+		return () => root.classList.remove('optimal-mode')
+	}, [settings.isOptimalMode])
+
+	useEffect(() => {
 		async function getTimeZone() {
 			if (user?.timeZone && user.timeZone !== settings?.selected_timezone?.value) {
 				const timezones = await getTimezones()

--- a/src/hooks/__tests__/use-delayed-unmount.test.ts
+++ b/src/hooks/__tests__/use-delayed-unmount.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test'
+import { EXIT_ANIMATION_MS } from '../use-delayed-unmount'
+
+function isDefined(value: unknown): boolean {
+	return value !== null && value !== undefined && value !== false
+}
+
+describe('EXIT_ANIMATION_MS', () => {
+	it('outlasts the daisyUI modal transition of 300ms', () => {
+		expect(EXIT_ANIMATION_MS).toBeGreaterThan(300)
+	})
+})
+
+describe('the retain predicate', () => {
+	it('treats real payloads as worth holding through the exit', () => {
+		expect(isDefined({ id: 1 })).toBe(true)
+		expect(isDefined('pomodoro')).toBe(true)
+		expect(isDefined(0)).toBe(true)
+		expect(isDefined('')).toBe(true)
+	})
+
+	it('treats the cleared states as released', () => {
+		expect(isDefined(null)).toBe(false)
+		expect(isDefined(undefined)).toBe(false)
+		expect(isDefined(false)).toBe(false)
+	})
+})

--- a/src/hooks/__tests__/use-delayed-unmount.test.ts
+++ b/src/hooks/__tests__/use-delayed-unmount.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from 'bun:test'
-import { EXIT_ANIMATION_MS } from '../use-delayed-unmount'
-
-function isDefined(value: unknown): boolean {
-	return value !== null && value !== undefined && value !== false
-}
+import {
+	EXIT_ANIMATION_MS,
+	isRetainableValue,
+} from '@/common/utils/animation-timing'
 
 describe('EXIT_ANIMATION_MS', () => {
 	it('outlasts the daisyUI modal transition of 300ms', () => {
@@ -11,17 +10,20 @@ describe('EXIT_ANIMATION_MS', () => {
 	})
 })
 
-describe('the retain predicate', () => {
-	it('treats real payloads as worth holding through the exit', () => {
-		expect(isDefined({ id: 1 })).toBe(true)
-		expect(isDefined('pomodoro')).toBe(true)
-		expect(isDefined(0)).toBe(true)
-		expect(isDefined('')).toBe(true)
+describe('isRetainableValue', () => {
+	it('holds real payloads through the exit animation', () => {
+		expect(isRetainableValue({ id: 1 })).toBe(true)
+		expect(isRetainableValue('pomodoro')).toBe(true)
 	})
 
-	it('treats the cleared states as released', () => {
-		expect(isDefined(null)).toBe(false)
-		expect(isDefined(undefined)).toBe(false)
-		expect(isDefined(false)).toBe(false)
+	it('holds falsy values that are still real content', () => {
+		expect(isRetainableValue(0)).toBe(true)
+		expect(isRetainableValue('')).toBe(true)
+	})
+
+	it('releases the cleared states', () => {
+		expect(isRetainableValue(null)).toBe(false)
+		expect(isRetainableValue(undefined)).toBe(false)
+		expect(isRetainableValue(false)).toBe(false)
 	})
 })

--- a/src/hooks/use-delayed-unmount.ts
+++ b/src/hooks/use-delayed-unmount.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef, useState } from 'react'
+
+export function useDelayedUnmount(isOpen: boolean, delayMs: number): boolean {
+	const [shouldRender, setShouldRender] = useState(isOpen)
+
+	useEffect(() => {
+		if (isOpen) {
+			setShouldRender(true)
+			return
+		}
+
+		const timer = setTimeout(() => setShouldRender(false), delayMs)
+		return () => clearTimeout(timer)
+	}, [isOpen, delayMs])
+
+	return isOpen || shouldRender
+}
+
+export function useLastDefined<T>(value: T): T {
+	const lastRef = useRef<T>(value)
+
+	if (value !== null && value !== undefined && value !== false) {
+		lastRef.current = value
+	}
+
+	return lastRef.current
+}

--- a/src/hooks/use-delayed-unmount.ts
+++ b/src/hooks/use-delayed-unmount.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
+export const EXIT_ANIMATION_MS = 360
+
 export function useDelayedUnmount(isOpen: boolean, delayMs: number): boolean {
 	const [shouldRender, setShouldRender] = useState(isOpen)
 
@@ -16,12 +18,25 @@ export function useDelayedUnmount(isOpen: boolean, delayMs: number): boolean {
 	return isOpen || shouldRender
 }
 
-export function useLastDefined<T>(value: T): T {
+export function useLastDefined<T>(value: T, retainMs = EXIT_ANIMATION_MS): T {
+	const [, forceRelease] = useState(0)
 	const lastRef = useRef<T>(value)
+	const isDefined = value !== null && value !== undefined && value !== false
 
-	if (value !== null && value !== undefined && value !== false) {
+	if (isDefined) {
 		lastRef.current = value
 	}
+
+	useEffect(() => {
+		if (isDefined) return
+
+		const timer = setTimeout(() => {
+			lastRef.current = value
+			forceRelease((tick) => tick + 1)
+		}, retainMs)
+
+		return () => clearTimeout(timer)
+	}, [isDefined, retainMs, value])
 
 	return lastRef.current
 }

--- a/src/hooks/use-delayed-unmount.ts
+++ b/src/hooks/use-delayed-unmount.ts
@@ -1,9 +1,16 @@
 import { useEffect, useRef, useState } from 'react'
+import { useGeneralSetting } from '@/context/general-setting.context'
+import {
+	EXIT_ANIMATION_MS,
+	isRetainableValue,
+} from '@/common/utils/animation-timing'
 
-export const EXIT_ANIMATION_MS = 360
+export { EXIT_ANIMATION_MS }
 
 export function useDelayedUnmount(isOpen: boolean, delayMs: number): boolean {
+	const { isOptimalMode } = useGeneralSetting()
 	const [shouldRender, setShouldRender] = useState(isOpen)
+	const effectiveDelay = isOptimalMode ? 0 : delayMs
 
 	useEffect(() => {
 		if (isOpen) {
@@ -11,17 +18,24 @@ export function useDelayedUnmount(isOpen: boolean, delayMs: number): boolean {
 			return
 		}
 
-		const timer = setTimeout(() => setShouldRender(false), delayMs)
+		if (effectiveDelay <= 0) {
+			setShouldRender(false)
+			return
+		}
+
+		const timer = setTimeout(() => setShouldRender(false), effectiveDelay)
 		return () => clearTimeout(timer)
-	}, [isOpen, delayMs])
+	}, [isOpen, effectiveDelay])
 
 	return isOpen || shouldRender
 }
 
 export function useLastDefined<T>(value: T, retainMs = EXIT_ANIMATION_MS): T {
+	const { isOptimalMode } = useGeneralSetting()
 	const [, forceRelease] = useState(0)
 	const lastRef = useRef<T>(value)
-	const isDefined = value !== null && value !== undefined && value !== false
+	const isDefined = isRetainableValue(value)
+	const effectiveRetain = isOptimalMode ? 0 : retainMs
 
 	if (isDefined) {
 		lastRef.current = value
@@ -33,10 +47,10 @@ export function useLastDefined<T>(value: T, retainMs = EXIT_ANIMATION_MS): T {
 		const timer = setTimeout(() => {
 			lastRef.current = value
 			forceRelease((tick) => tick + 1)
-		}, retainMs)
+		}, effectiveRetain)
 
 		return () => clearTimeout(timer)
-	}, [isDefined, retainMs, value])
+	}, [isDefined, effectiveRetain, value])
 
 	return lastRef.current
 }

--- a/src/index.css
+++ b/src/index.css
@@ -184,6 +184,13 @@ input[type="color"]::-moz-color-swatch {
   display: none;
 }
 
+html.optimal-mode *,
+html.optimal-mode *::before,
+html.optimal-mode *::after {
+  transition-duration: 0s !important;
+  transition-delay: 0s !important;
+}
+
 html.modal-isActive {
   scrollbar-width: none !important;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -212,24 +212,6 @@ img {
   -o-user-select: none;
 }
 
-/* Modal animations */
-@keyframes modal-in {
-  from {
-    opacity: 0;
-    transform: scale(0.95) translateY(10px);
-  }
-
-  to {
-    opacity: 1;
-    transform: scale(1) translateY(0);
-  }
-}
-
-.animate-modal-in {
-  animation: modal-in 0.2s ease-out;
-}
-
-
 /* updater */
 
 /* Vertical Writing Mode */

--- a/src/layouts/bookmark/bookmark-grid.tsx
+++ b/src/layouts/bookmark/bookmark-grid.tsx
@@ -1,7 +1,8 @@
 import { rectSortingStrategy, SortableContext } from '@dnd-kit/sortable'
 import { useIsMutating } from '@tanstack/react-query'
 import Analytics from '@/analytics'
-import { ConfirmationModal } from '@/components/ui'
+import { ConfirmationModal, MODAL_EXIT_MS } from '@/components/ui'
+import { useDelayedUnmount } from '@/hooks/use-delayed-unmount'
 import { useGeneralSetting } from '@/context/general-setting.context'
 import type { Bookmark, FolderPathItem } from './types/bookmark.types'
 import { openBookmarksOptimized } from './utils/tab-manager'
@@ -43,6 +44,7 @@ export function BookmarkGrid({
 	const { isAuthenticated } = useAuth()
 
 	const [showEditBookmarkModal, setShowEditBookmarkModal] = useState(false)
+	const shouldMountEdit = useDelayedUnmount(showEditBookmarkModal, MODAL_EXIT_MS)
 	const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] = useState(false)
 	const [bookmarkToEdit, setBookmarkToEdit] = useState<Bookmark | null>(null)
 	const [selectedBookmark, setSelectedBookmark] = useState<Bookmark | null>(null)
@@ -263,14 +265,16 @@ export function BookmarkGrid({
 					loginButtonText="ورود به حساب کاربری"
 				/>
 			) : (
-				<EditBookmarkModal
-					isOpen={showEditBookmarkModal}
-					onClose={() => setShowEditBookmarkModal(false)}
-					onSave={(bookmark) =>
-						editBookmark(bookmark, () => setShowEditBookmarkModal(false))
-					}
-					bookmark={bookmarkToEdit}
-				/>
+				shouldMountEdit && (
+					<EditBookmarkModal
+						isOpen={showEditBookmarkModal}
+						onClose={() => setShowEditBookmarkModal(false)}
+						onSave={(bookmark) =>
+							editBookmark(bookmark, () => setShowEditBookmarkModal(false))
+						}
+						bookmark={bookmarkToEdit}
+					/>
+				)
 			)}
 
 			<ConfirmationModal

--- a/src/layouts/bookmark/bookmark-grid.tsx
+++ b/src/layouts/bookmark/bookmark-grid.tsx
@@ -263,17 +263,14 @@ export function BookmarkGrid({
 					loginButtonText="ورود به حساب کاربری"
 				/>
 			) : (
-				showEditBookmarkModal &&
-				bookmarkToEdit && (
-					<EditBookmarkModal
-						isOpen={showEditBookmarkModal}
-						onClose={() => setShowEditBookmarkModal(false)}
-						onSave={(bookmark) =>
-							editBookmark(bookmark, () => setShowEditBookmarkModal(false))
-						}
-						bookmark={bookmarkToEdit}
-					/>
-				)
+				<EditBookmarkModal
+					isOpen={showEditBookmarkModal}
+					onClose={() => setShowEditBookmarkModal(false)}
+					onSave={(bookmark) =>
+						editBookmark(bookmark, () => setShowEditBookmarkModal(false))
+					}
+					bookmark={bookmarkToEdit}
+				/>
 			)}
 
 			<ConfirmationModal

--- a/src/layouts/bookmark/bookmarks.tsx
+++ b/src/layouts/bookmark/bookmarks.tsx
@@ -21,6 +21,8 @@ import { showToast } from '@/common/toast'
 import { translateError } from '@/common/utils/translate-error'
 import { useUpdateBookmarkOrder } from '@/services/hooks/bookmark/update-bookmark-order.hook'
 import { usePrimaryBookmarkInstanceId } from '@/context/free-widget.context'
+import { useDelayedUnmount } from '@/hooks/use-delayed-unmount'
+import { MODAL_EXIT_MS } from '@/components/ui'
 import type { WidgetSize } from '../widgets/layout-engine/types'
 import { validate } from 'uuid'
 
@@ -42,6 +44,8 @@ export function BookmarksList({ size, instanceId }: BookmarksListProps = {}) {
 	const [showAddBookmarkModal, setShowAddBookmarkModal] = useState(false)
 	const [showImportBookmarksModal, setShowImportBookmarksModal] = useState(false)
 	const [folderModalPath, setFolderModalPath] = useState<FolderPathItem[]>([])
+	const shouldMountFolder = useDelayedUnmount(folderModalPath.length > 0, MODAL_EXIT_MS)
+	const shouldMountImport = useDelayedUnmount(showImportBookmarksModal, MODAL_EXIT_MS)
 	const { mutateAsync: updateOrder } = useUpdateBookmarkOrder()
 	const [folderPath, setFolderPath] = useState<FolderPathItem[]>([])
 
@@ -228,14 +232,16 @@ export function BookmarksList({ size, instanceId }: BookmarksListProps = {}) {
 				</div>
 			</DndContext>
 
-			<BookmarkFolderModal
-				isOpen={folderModalPath.length > 0}
+			{shouldMountFolder && (
+				<BookmarkFolderModal
+					isOpen={folderModalPath.length > 0}
 				onClose={() => setFolderModalPath([])}
 				folderPath={folderModalPath}
-				setFolderPath={setFolderModalPath}
-				instanceId={instanceId}
-				isPrimary={isPrimary}
-			/>
+					setFolderPath={setFolderModalPath}
+					instanceId={instanceId}
+					isPrimary={isPrimary}
+				/>
+			)}
 			{showAddBookmarkModal && !isAuthenticated ? (
 				<AuthRequiredModal
 					isOpen={true}
@@ -260,11 +266,13 @@ export function BookmarksList({ size, instanceId }: BookmarksListProps = {}) {
 					/>
 				)
 			)}
-			<ImportBrowserBookmarksModal
-				isOpen={showImportBookmarksModal}
-				onClose={() => setShowImportBookmarksModal(false)}
-				parentId={currentFolderId}
-			/>
+			{shouldMountImport && (
+				<ImportBrowserBookmarksModal
+					isOpen={showImportBookmarksModal}
+					onClose={() => setShowImportBookmarksModal(false)}
+					parentId={currentFolderId}
+				/>
+			)}
 		</>
 	)
 }

--- a/src/layouts/bookmark/bookmarks.tsx
+++ b/src/layouts/bookmark/bookmarks.tsx
@@ -228,16 +228,14 @@ export function BookmarksList({ size, instanceId }: BookmarksListProps = {}) {
 				</div>
 			</DndContext>
 
-			{folderModalPath.length > 0 && (
-				<BookmarkFolderModal
-					isOpen={folderModalPath.length > 0}
-					onClose={() => setFolderModalPath([])}
-					folderPath={folderModalPath}
-					setFolderPath={setFolderModalPath}
-					instanceId={instanceId}
-					isPrimary={isPrimary}
-				/>
-			)}
+			<BookmarkFolderModal
+				isOpen={folderModalPath.length > 0}
+				onClose={() => setFolderModalPath([])}
+				folderPath={folderModalPath}
+				setFolderPath={setFolderModalPath}
+				instanceId={instanceId}
+				isPrimary={isPrimary}
+			/>
 			{showAddBookmarkModal && !isAuthenticated ? (
 				<AuthRequiredModal
 					isOpen={true}
@@ -262,13 +260,11 @@ export function BookmarksList({ size, instanceId }: BookmarksListProps = {}) {
 					/>
 				)
 			)}
-			{showImportBookmarksModal && (
-				<ImportBrowserBookmarksModal
-					isOpen={showImportBookmarksModal}
-					onClose={() => setShowImportBookmarksModal(false)}
-					parentId={currentFolderId}
-				/>
-			)}
+			<ImportBrowserBookmarksModal
+				isOpen={showImportBookmarksModal}
+				onClose={() => setShowImportBookmarksModal(false)}
+				parentId={currentFolderId}
+			/>
 		</>
 	)
 }

--- a/src/layouts/bookmark/components/modal/advanced.modal.tsx
+++ b/src/layouts/bookmark/components/modal/advanced.modal.tsx
@@ -148,8 +148,6 @@ export function AdvancedModal({ title, onClose, isOpen, bookmark }: AdvancedModa
 		})
 	}
 
-	if (!isOpen) return null
-
 	return (
 		<Modal
 			title={title}

--- a/src/layouts/bookmark/components/modal/bookmark-folder.modal.tsx
+++ b/src/layouts/bookmark/components/modal/bookmark-folder.modal.tsx
@@ -8,7 +8,8 @@ import {
 } from '@dnd-kit/core'
 import { useState } from 'react'
 import Analytics from '@/analytics'
-import { Modal } from '@/components/ui'
+import { MODAL_EXIT_MS, Modal } from '@/components/ui'
+import { useDelayedUnmount } from '@/hooks/use-delayed-unmount'
 import { showToast } from '@/common/toast'
 import { translateError } from '@/common/utils/translate-error'
 import { useAuth } from '@/context/auth.context'
@@ -47,6 +48,7 @@ export function BookmarkFolderModal({
 
 	const [showAddModal, setShowAddModal] = useState(false)
 	const [showImportModal, setShowImportModal] = useState(false)
+	const shouldMountImport = useDelayedUnmount(showImportModal, MODAL_EXIT_MS)
 
 	const sensors = useSensors(
 		useSensor(PointerSensor, {
@@ -238,11 +240,13 @@ export function BookmarkFolderModal({
 				)
 			)}
 
-			<ImportBrowserBookmarksModal
-				isOpen={showImportModal}
-				onClose={() => setShowImportModal(false)}
-				parentId={currentFolderId}
-			/>
+			{shouldMountImport && (
+				<ImportBrowserBookmarksModal
+					isOpen={showImportModal}
+					onClose={() => setShowImportModal(false)}
+					parentId={currentFolderId}
+				/>
+			)}
 		</Modal>
 	)
 }

--- a/src/layouts/bookmark/components/modal/bookmark-folder.modal.tsx
+++ b/src/layouts/bookmark/components/modal/bookmark-folder.modal.tsx
@@ -238,13 +238,11 @@ export function BookmarkFolderModal({
 				)
 			)}
 
-			{showImportModal && (
-				<ImportBrowserBookmarksModal
-					isOpen={showImportModal}
-					onClose={() => setShowImportModal(false)}
-					parentId={currentFolderId}
-				/>
-			)}
+			<ImportBrowserBookmarksModal
+				isOpen={showImportModal}
+				onClose={() => setShowImportModal(false)}
+				parentId={currentFolderId}
+			/>
 		</Modal>
 	)
 }

--- a/src/layouts/bookmark/components/modal/edit-bookmark.modal.tsx
+++ b/src/layouts/bookmark/components/modal/edit-bookmark.modal.tsx
@@ -1,3 +1,4 @@
+import { useLastDefined } from '@/hooks/use-delayed-unmount'
 import { getFaviconFromUrl } from '@/common/utils/icon'
 import { Button, Modal } from '@/components/ui'
 import { TextInput } from '@/components/ui'
@@ -12,7 +13,7 @@ interface EditBookmarkModalProps {
 	isOpen: boolean
 	onClose: () => void
 	onSave: (out: BookmarkUpdateFormFields) => void
-	bookmark: Bookmark
+	bookmark: Bookmark | null
 }
 
 export interface BookmarkUpdateFormFields {
@@ -144,7 +145,8 @@ export function EditBookmarkModal({
 		}
 	}, [bookmark])
 
-	if (!bookmark) return null
+	const safeBookmark = useLastDefined(bookmark)
+	if (!safeBookmark) return null
 
 	return (
 		<Modal
@@ -247,7 +249,7 @@ export function EditBookmarkModal({
 					customBackground: formData.customBackground,
 					customTextColor: formData.customTextColor,
 					sticker: formData.sticker,
-					type: bookmark.type,
+					type: safeBookmark.type,
 					title: formData.title,
 					url: formData.url,
 				}}

--- a/src/layouts/friends/friends.tsx
+++ b/src/layouts/friends/friends.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useLastDefined } from '@/hooks/use-delayed-unmount'
 import { type Friend, useRemoveFriend } from '@/services/hooks/friends/friend-service.hook'
 import { translateError } from '@/common/utils/translate-error'
 import { showToast } from '@/common/toast'
@@ -15,6 +16,7 @@ export const FriendsLayout = () => {
 	const [isAddFriendOpen, setIsAddFriendOpen] = useState(false)
 
 	const [selectedUser, setSelectedUser] = useState<Friend | null>()
+	const lastSelectedUser = useLastDefined(selectedUser)
 
 	const { mutate: removeFriend, isPending: isRemoving } = useRemoveFriend()
 
@@ -83,16 +85,14 @@ export const FriendsLayout = () => {
 				<AddFriendBottomSheet isOpen onClose={() => setIsAddFriendOpen(false)} />
 			)}
 
-			{selectedUser && (
-				<ConfirmationModal
-					isOpen
-					direction="rtl"
-					isLoading={isRemoving}
-					onClose={() => setSelectedUser(null)}
-					onConfirm={() => handleRemoveFriend(selectedUser?.id || null)}
-					message={`"${selectedUser?.user.name}"، حذف بشه از لیست دوستات؟`}
-				/>
-			)}
+			<ConfirmationModal
+				isOpen={!!selectedUser}
+				direction="rtl"
+				isLoading={isRemoving}
+				onClose={() => setSelectedUser(null)}
+				onConfirm={() => handleRemoveFriend(lastSelectedUser?.id || null)}
+				message={`"${lastSelectedUser?.user.name}"، حذف بشه از لیست دوستات؟`}
+			/>
 		</>
 	)
 }

--- a/src/layouts/market/market-coins/components/coin-package-purchase-modal.tsx
+++ b/src/layouts/market/market-coins/components/coin-package-purchase-modal.tsx
@@ -1,3 +1,4 @@
+import { useLastDefined } from '@/hooks/use-delayed-unmount'
 import Analytics from '@/analytics'
 import { Button, Modal } from '@/components/ui'
 import { translateError } from '@/common/utils/translate-error'
@@ -26,11 +27,12 @@ export function CoinPackagePurchaseModal({
 }: CoinPackagePurchaseModalProps) {
 	const { mutate: purchasePackage, isPending } = usePurchaseCoinPackage()
 
-	if (!pkg) return null
+	const safePkg = useLastDefined(pkg)
+	if (!safePkg) return null
 
 	const handlePurchase = () => {
 		purchasePackage(
-			{ packageId: pkg.id },
+			{ packageId: safePkg.id },
 			{
 				onSuccess: (_response) => {
 					showToast('در حال انتقال ...', 'success')
@@ -69,7 +71,7 @@ export function CoinPackagePurchaseModal({
 							/>
 							<div className="flex items-baseline gap-1.5">
 								<span className="text-4xl font-bold text-primary tabular-nums">
-									{formatPrice(pkg.coin)}
+									{formatPrice(safePkg.coin)}
 								</span>
 								<span className="text-sm text-muted">ویج‌کوین</span>
 							</div>
@@ -77,10 +79,10 @@ export function CoinPackagePurchaseModal({
 					</div>
 					<div className="px-3 py-2.5">
 						<h3 className="text-sm font-semibold text-content">
-							{pkg.title}
+							{safePkg.title}
 						</h3>
-						{pkg.description && (
-							<p className="mt-0.5 text-xs text-muted">{pkg.description}</p>
+						{safePkg.description && (
+							<p className="mt-0.5 text-xs text-muted">{safePkg.description}</p>
 						)}
 					</div>
 				</div>
@@ -90,7 +92,7 @@ export function CoinPackagePurchaseModal({
 						<span className="text-xs text-muted">مبلغ قابل پرداخت</span>
 						<div className="flex items-baseline gap-1">
 							<span className="text-lg font-bold text-content tabular-nums">
-								{formatPrice(pkg.price)}
+								{formatPrice(safePkg.price)}
 							</span>
 							<span className="text-xs text-muted">تومان</span>
 						</div>

--- a/src/layouts/market/other-items/components/market-item-purchase-modal.tsx
+++ b/src/layouts/market/other-items/components/market-item-purchase-modal.tsx
@@ -1,3 +1,4 @@
+import { useLastDefined } from '@/hooks/use-delayed-unmount'
 import Analytics from '@/analytics'
 import { ItemPrice } from '@/components/item-price/item-price'
 import { Button, Modal } from '@/components/ui'
@@ -25,23 +26,24 @@ export function MarketItemPurchaseModal({
 }: MarketItemPurchaseModalProps) {
 	const { mutate: purchaseItem, isPending } = usePurchaseMarketItem()
 
-	if (!item) return null
+	const safeItem = useLastDefined(item)
+	if (!safeItem) return null
 
-	const canAfford = userCoins >= item.price
-	const remainingCoins = userCoins - item.price
+	const canAfford = userCoins >= safeItem.price
+	const remainingCoins = userCoins - safeItem.price
 
 	const handlePurchase = () => {
 		if (!canAfford) return
 
 		purchaseItem(
-			{ itemId: item.id },
+			{ itemId: safeItem.id },
 			{
 				onSuccess: (_response) => {
-					showToast(`${item.name} با موفقیت خریداری شد! 🎉`, 'success', {
+					showToast(`${safeItem.name} با موفقیت خریداری شد! 🎉`, 'success', {
 						alarmSound: true,
 					})
 					Analytics.event('market_item_purchased')
-					onPurchaseSuccess(item)
+					onPurchaseSuccess(safeItem)
 				},
 				onError: (error) => {
 					showToast(
@@ -66,14 +68,14 @@ export function MarketItemPurchaseModal({
 		>
 			<div className="space-y-3">
 				<div className="overflow-hidden border rounded-2xl border-base-300/60 bg-base-100">
-					<RenderPreview item={item} handlePreviewClick={() => {}} />
+					<RenderPreview item={safeItem} handlePreviewClick={() => {}} />
 					<div className="px-3 py-2.5">
 						<h3 className="text-sm font-semibold text-content">
-							{item.name}
+							{safeItem.name}
 						</h3>
-						{item.description && (
+						{safeItem.description && (
 							<p className="mt-0.5 text-xs text-muted">
-								{item.description}
+								{safeItem.description}
 							</p>
 						)}
 					</div>
@@ -86,7 +88,7 @@ export function MarketItemPurchaseModal({
 					</div>
 					<div className="flex items-center justify-between px-3 py-2.5">
 						<span className="text-xs text-muted">قیمت آیتم</span>
-						<ItemPrice price={item.price} />
+						<ItemPrice price={safeItem.price} />
 					</div>
 					<div className="flex items-center justify-between px-3 py-2.5">
 						<span className="text-xs font-medium text-content">
@@ -109,7 +111,7 @@ export function MarketItemPurchaseModal({
 								موجودی ناکافی
 							</p>
 							<p className="text-[11px] text-error/75 mt-0.5">
-								برای خرید این آیتم به {item.price - userCoins} ویج‌کوین
+								برای خرید این آیتم به {safeItem.price - userCoins} ویج‌کوین
 								بیشتر نیاز دارید
 							</p>
 						</div>

--- a/src/layouts/mini-apps/mini-apps.layout.tsx
+++ b/src/layouts/mini-apps/mini-apps.layout.tsx
@@ -146,10 +146,9 @@ export function MiniAppsLayout() {
 				</div>
 			</div>
 
-			{showInfo && (
-				<Modal
+			<Modal
 					title="برنامک ها"
-					isOpen
+					isOpen={showInfo}
 					onClose={() => setShowInfo(false)}
 					direction="rtl"
 				>
@@ -183,7 +182,6 @@ export function MiniAppsLayout() {
 						باشه
 					</Button>
 				</Modal>
-			)}
 		</div>
 	)
 }

--- a/src/layouts/navbar/friends-list/friends.navbar.tsx
+++ b/src/layouts/navbar/friends-list/friends.navbar.tsx
@@ -87,16 +87,14 @@ export function FriendsListNavbar() {
 					<ActiveFriendsHorizontal />
 				</div>
 			</BottomSheet>
-			{firstAuth && (
-				<AuthRequiredModal
-					isOpen={firstAuth}
-					onClose={handleAuthModalClose}
-					title="ورود به حساب کاربری"
-					message="برای دسترسی به بخش مدیریت دوستان، ابتدا وارد حساب کاربری خود شوید."
-					loginButtonText="ورود به حساب"
-					cancelButtonText="بعدا"
-				/>
-			)}
+			<AuthRequiredModal
+				isOpen={firstAuth}
+				onClose={handleAuthModalClose}
+				title="ورود به حساب کاربری"
+				message="برای دسترسی به بخش مدیریت دوستان، ابتدا وارد حساب کاربری خود شوید."
+				loginButtonText="ورود به حساب"
+				cancelButtonText="بعدا"
+			/>
 		</>
 	)
 }

--- a/src/layouts/navbar/navbar.layout.tsx
+++ b/src/layouts/navbar/navbar.layout.tsx
@@ -95,6 +95,7 @@ export function NavbarLayout(): JSX.Element {
 	const { canvasMode } = useAppearance()
 	const isEditingCanvas = canvasMode === 'edit'
 	const showNavbar = isVisible && !isEditingCanvas
+	const showHandle = !isVisible && !isEditingCanvas
 	const [tab, setTab] = useState<string | null>(null)
 	const handleOpenSettings = useCallback((tabName: string | null) => {
 		if (showSettings) {
@@ -134,17 +135,21 @@ export function NavbarLayout(): JSX.Element {
 	useBirthdayConfetti(user?.isBirthdayToday || false)
 	return (
 		<>
-			{!isVisible && !isEditingCanvas && (
-				<button
-					onClick={() => onToggleNavbar()}
-					className="fixed z-50 bottom-0 left-1/2 -translate-x-1/2 w-28 py-2.5 bg-content bg-glass border-t border-x border-white/10 rounded-t-3xl shadow-[0_-0px_30px_rgba(0,0,0,0.3)] transition-all hover:bg-white/[0.08] cursor-pointer group"
-				>
-					<div className="w-10 h-1 mx-auto transition-all duration-200 rounded-full bg-base-content/50 group-hover:w-12" />
-				</button>
-			)}
+			<button
+				onClick={() => onToggleNavbar()}
+				aria-hidden={showHandle ? undefined : true}
+				tabIndex={showHandle ? 0 : -1}
+				className={`fixed z-50 bottom-0 left-1/2 -translate-x-1/2 w-28 py-2.5 bg-content bg-glass border-t border-x border-white/10 rounded-t-3xl shadow-[0_-0px_30px_rgba(0,0,0,0.3)] transition-all duration-500 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-white/[0.08] cursor-pointer group ${
+					showHandle
+						? 'translate-y-0 opacity-100'
+						: 'translate-y-full opacity-0 pointer-events-none'
+				}`}
+			>
+				<div className="w-10 h-1 mx-auto transition-all duration-200 rounded-full bg-base-content/50 group-hover:w-12" />
+			</button>
 
 			<div
-				className={`fixed z-60  -translate-x-1/2 left-1/2 w-full px-2 md:px-8 lg:px-4 max-w-[1080px] transition-all ease-[cubic-bezier(0.23,1,0.32,1)] 
+				className={`fixed z-60  -translate-x-1/2 left-1/2 w-full px-2 md:px-8 lg:px-4 max-w-[1080px] transition-all duration-500 ease-[cubic-bezier(0.23,1,0.32,1)] 
 					${
 						showNavbar
 							? 'bottom-2 opacity-100 scale-100'

--- a/src/layouts/search/browser-bookmark/bookmark-popover.tsx
+++ b/src/layouts/search/browser-bookmark/bookmark-popover.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { Motion, Presence } from '@/common/motion'
+import { Portal } from '@/components/ui'
 import { getFaviconFromUrl } from '@/common/utils/icon'
 import { useGeneralSetting } from '@/context/general-setting.context'
 import {
@@ -43,8 +44,6 @@ export function BookmarkPopover({ isOpen, onClose, coords }: BookmarkPopoverProp
 		return () => document.removeEventListener('mousedown', handleClickOutside)
 	}, [isOpen, onClose])
 
-	if (!isOpen) return null
-
 	const displayItems = fetchedBookmarks.filter((b) => {
 		if (currentFolderId) return b.parentId === currentFolderId
 		return b.parentId === '0' || b.parentId === 'root' || !b.parentId
@@ -74,9 +73,17 @@ export function BookmarkPopover({ isOpen, onClose, coords }: BookmarkPopoverProp
 	const c =
 		fetchedBookmarks.find((b) => b.id === currentFolderId)?.title || 'بوکمارک‌های من'
 
-	return createPortal(
-		<div
-			className="bookmark-popover fixed z-popover w-72  border border-base-content/10 shadow-2xl rounded-2xl overflow-hidden animate-in fade-in zoom-in duration-200 origin-top-left bg-content bg-glass"
+	return (
+		<Portal>
+			<Presence>
+				{isOpen && (
+		<Motion.div
+			key="bookmark-popover"
+			className="bookmark-popover fixed z-popover w-72  border border-base-content/10 shadow-2xl rounded-2xl overflow-hidden origin-top-left bg-content bg-glass"
+			initial={{ opacity: 0, scale: 0.95 }}
+			animate={{ opacity: 1, scale: 1 }}
+			exit={{ opacity: 0, scale: 0.95 }}
+			transition={{ duration: 0.15, ease: 'easeOut' }}
 			style={{
 				top: coords.top,
 				left: coords.left,
@@ -168,7 +175,9 @@ export function BookmarkPopover({ isOpen, onClose, coords }: BookmarkPopoverProp
 					</div>
 				</div>
 			)}
-		</div>,
-		document.body
+		</Motion.div>
+				)}
+			</Presence>
+		</Portal>
 	)
 }

--- a/src/layouts/search/history.portal.tsx
+++ b/src/layouts/search/history.portal.tsx
@@ -4,11 +4,13 @@ import { SuggestionSkeleton } from './suggestion/suggestion.skeleton'
 import { useAuth } from '@/context/auth.context'
 import { AutocompleteConsentModal } from './suggestion/autocomplete-consent.modal'
 import { Portal } from '@/components/ui'
+import { Motion, Presence } from '@/common/motion'
 import { useSearchHistory } from './hooks/use-search-history'
 import { Suggestions } from './suggestion/suggestions'
 import { Icon } from '@/src/icons'
 
 interface SearchHistoryPortalProps {
+	isOpen: boolean
 	onClose: () => void
 	onSearch: (query: string) => void
 	onEngineChange: any
@@ -18,6 +20,7 @@ interface SearchHistoryPortalProps {
 }
 
 export function SearchHistoryPortal({
+	isOpen,
 	onSearch,
 	searchQuery,
 	portalStyles,
@@ -77,10 +80,17 @@ export function SearchHistoryPortal({
 	return (
 		<>
 			<Portal>
-				<div
+				<Presence>
+					{isOpen && (
+				<Motion.div
+					key="search-history"
 					ref={portalRef}
 					style={portalStyles}
-					className="z-20 -mt-12 overflow-hidden duration-300 shadow-2xl bg-content bg-glass h-60 rounded-b-2xl rounded-t-md animate-in fade-in slide-in-from-top-2"
+					initial={{ opacity: 0, y: -8 }}
+					animate={{ opacity: 1, y: 0 }}
+					exit={{ opacity: 0, y: -8 }}
+					transition={{ duration: 0.18, ease: 'easeOut' }}
+					className="z-20 -mt-12 overflow-hidden shadow-2xl bg-content bg-glass h-60 rounded-b-2xl rounded-t-md"
 				>
 					{showSuggestions &&
 						hasQuery &&
@@ -144,15 +154,15 @@ export function SearchHistoryPortal({
 								</p>
 							</div>
 						)}
-				</div>
+				</Motion.div>
+					)}
+				</Presence>
 			</Portal>
 
-			{showConsentModal && (
-				<AutocompleteConsentModal
-					isOpen
-					onClose={() => setShowConsentModal(false)}
-				/>
-			)}
+			<AutocompleteConsentModal
+				isOpen={showConsentModal}
+				onClose={() => setShowConsentModal(false)}
+			/>
 		</>
 	)
 }

--- a/src/layouts/search/search.tsx
+++ b/src/layouts/search/search.tsx
@@ -245,16 +245,15 @@ function SearchFullContent({ size }: SearchLayoutProps) {
 					/>
 				)}
 
-				{showHistoryPortal && !activePortal && (
-					<SearchHistoryPortal
-						portalRef={portalRef}
-						onClose={() => setShowHistoryPortal(false)}
-						onSearch={handleHistorySearch}
-						onEngineChange={onEngineChange}
-						searchQuery={searchQuery}
-						portalStyles={portalStyles}
-					/>
-				)}
+				<SearchHistoryPortal
+					isOpen={showHistoryPortal && !activePortal}
+					portalRef={portalRef}
+					onClose={() => setShowHistoryPortal(false)}
+					onSearch={handleHistorySearch}
+					onEngineChange={onEngineChange}
+					searchQuery={searchQuery}
+					portalStyles={portalStyles}
+				/>
 
 				<BrowserBookmark />
 			</div>

--- a/src/layouts/search/search.tsx
+++ b/src/layouts/search/search.tsx
@@ -7,6 +7,8 @@ import { VoiceSearchPortal } from './voice/voice-search.portal'
 import { ImageSearchButton } from './image/image-search.button'
 import { EngineSelector } from './select-engine/engine-selector'
 import { SearchHistoryPortal } from './history.portal'
+import { useDelayedUnmount } from '@/hooks/use-delayed-unmount'
+import { MODAL_EXIT_MS } from '@/components/ui'
 import { SearchCompactRow } from './variants/search-2x1'
 import type { EngineMeta } from '@/services/hooks/trends/get-trends'
 import { useSearchHistory } from './hooks/use-search-history'
@@ -36,6 +38,8 @@ function SearchFullContent({ size }: SearchLayoutProps) {
 	const portalRef = useRef<HTMLDivElement>(null)
 	const inputRef = useRef<HTMLInputElement>(null)
 	const [activePortal, setActivePortal] = useState<'voice' | 'image' | null>(null)
+	const isHistoryOpen = showHistoryPortal && !activePortal
+	const shouldMountHistory = useDelayedUnmount(isHistoryOpen, MODAL_EXIT_MS)
 	const [portalStyles, setPortalStyles] = useState<React.CSSProperties>({})
 	const { user } = useAuth()
 
@@ -245,15 +249,17 @@ function SearchFullContent({ size }: SearchLayoutProps) {
 					/>
 				)}
 
-				<SearchHistoryPortal
-					isOpen={showHistoryPortal && !activePortal}
-					portalRef={portalRef}
-					onClose={() => setShowHistoryPortal(false)}
-					onSearch={handleHistorySearch}
-					onEngineChange={onEngineChange}
-					searchQuery={searchQuery}
-					portalStyles={portalStyles}
-				/>
+				{shouldMountHistory && (
+					<SearchHistoryPortal
+						isOpen={isHistoryOpen}
+						portalRef={portalRef}
+						onClose={() => setShowHistoryPortal(false)}
+						onSearch={handleHistorySearch}
+						onEngineChange={onEngineChange}
+						searchQuery={searchQuery}
+						portalStyles={portalStyles}
+					/>
+				)}
 
 				<BrowserBookmark />
 			</div>

--- a/src/layouts/search/variants/search-2x1.tsx
+++ b/src/layouts/search/variants/search-2x1.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import Analytics from '@/analytics'
 import { EngineSelector } from '../select-engine/engine-selector'
 import { SearchHistoryPortal } from '../history.portal'
+import { useDelayedUnmount } from '@/hooks/use-delayed-unmount'
+import { MODAL_EXIT_MS } from '@/components/ui'
 import type { EngineMeta } from '@/services/hooks/trends/get-trends'
 import { useSearchHistory } from '../hooks/use-search-history'
 import { useAuth } from '@/context/auth.context'
@@ -18,6 +20,7 @@ export function SearchCompactRow() {
 	const [searchQuery, setSearchQuery] = useState('')
 	const [selectedEngine, setSelectedEngine] = useState<EngineMeta>(DEFAULT_ENGINE)
 	const [showHistoryPortal, setShowHistoryPortal] = useState(false)
+	const shouldMountHistory = useDelayedUnmount(showHistoryPortal, MODAL_EXIT_MS)
 	const searchRef = useRef<HTMLDivElement>(null)
 	const portalRef = useRef<HTMLDivElement>(null)
 	const inputRef = useRef<HTMLInputElement>(null)
@@ -186,15 +189,17 @@ export function SearchCompactRow() {
 					</div>
 				</form>
 
-				<SearchHistoryPortal
-					isOpen={showHistoryPortal}
-					portalRef={portalRef}
-					onClose={() => setShowHistoryPortal(false)}
-					onSearch={handleHistorySearch}
-					onEngineChange={onEngineChange}
-					searchQuery={searchQuery}
-					portalStyles={portalStyles}
-				/>
+				{shouldMountHistory && (
+					<SearchHistoryPortal
+						isOpen={showHistoryPortal}
+						portalRef={portalRef}
+						onClose={() => setShowHistoryPortal(false)}
+						onSearch={handleHistorySearch}
+						onEngineChange={onEngineChange}
+						searchQuery={searchQuery}
+						portalStyles={portalStyles}
+					/>
+				)}
 			</div>
 		</div>
 	)

--- a/src/layouts/search/variants/search-2x1.tsx
+++ b/src/layouts/search/variants/search-2x1.tsx
@@ -186,16 +186,15 @@ export function SearchCompactRow() {
 					</div>
 				</form>
 
-				{showHistoryPortal && (
-					<SearchHistoryPortal
-						portalRef={portalRef}
-						onClose={() => setShowHistoryPortal(false)}
-						onSearch={handleHistorySearch}
-						onEngineChange={onEngineChange}
-						searchQuery={searchQuery}
-						portalStyles={portalStyles}
-					/>
-				)}
+				<SearchHistoryPortal
+					isOpen={showHistoryPortal}
+					portalRef={portalRef}
+					onClose={() => setShowHistoryPortal(false)}
+					onSearch={handleHistorySearch}
+					onEngineChange={onEngineChange}
+					searchQuery={searchQuery}
+					portalStyles={portalStyles}
+				/>
 			</div>
 		</div>
 	)

--- a/src/layouts/setting/tabs/account/account.tsx
+++ b/src/layouts/setting/tabs/account/account.tsx
@@ -8,7 +8,7 @@ export const AccountTab = () => {
 
 	return (
 		<div className="w-full h-full max-w-xl mx-auto">
-			<Presence mode="wait">
+			<Presence mode="wait" initial={false}>
 				{isAuthenticated ? (
 					<motion.div
 						key="profile"

--- a/src/layouts/setting/tabs/account/tabs/user-profile/connections/components/connection-modal.tsx
+++ b/src/layouts/setting/tabs/account/tabs/user-profile/connections/components/connection-modal.tsx
@@ -1,3 +1,4 @@
+import { useLastDefined } from '@/hooks/use-delayed-unmount'
 import { Button, Modal } from '@/components/ui'
 import type { Platform } from './platform-config.js'
 
@@ -16,7 +17,8 @@ export function ConnectionModal({
 	onConfirm,
 	isLoading,
 }: ConnectionModalProps) {
-	if (!platform) return null
+	const safePlatform = useLastDefined(platform)
+	if (!safePlatform) return null
 
 	return (
 		<Modal
@@ -28,20 +30,20 @@ export function ConnectionModal({
 			<div className="p-4">
 				<div className="flex items-center gap-3 mb-4">
 					<div
-						className={`flex items-center justify-center w-10 h-10 ${platform.bgColor} rounded-lg`}
+						className={`flex items-center justify-center w-10 h-10 ${safePlatform.bgColor} rounded-lg`}
 					>
-						{platform.icon}
+						{safePlatform.icon}
 					</div>
 					<h2 className="text-xl font-semibold text-content">
-						{platform.connected ? 'قطع اتصال از' : 'اتصال به'} {platform.name}
+						{safePlatform.connected ? 'قطع اتصال از' : 'اتصال به'} {safePlatform.name}
 					</h2>
 				</div>
 
 				<div className="mb-6">
-					{platform.connected ? (
+					{safePlatform.connected ? (
 						<div className="space-y-2">
 							<p className="text-content">
-								آیا مطمئن هستید که می‌خواهید اتصال به {platform.name} را
+								آیا مطمئن هستید که می‌خواهید اتصال به {safePlatform.name} را
 								قطع کنید؟
 							</p>
 							<div className="p-3 text-sm rounded-2xl text-warning-content bg-warning/80">
@@ -51,14 +53,14 @@ export function ConnectionModal({
 						</div>
 					) : (
 						<div className="space-y-3">
-							<p className="text-content">{platform.description}</p>
-							{platform.features && platform.features.length > 0 && (
+							<p className="text-content">{safePlatform.description}</p>
+							{safePlatform.features && safePlatform.features.length > 0 && (
 								<div>
 									<p className="mb-2 text-sm font-medium text-content">
 										امکانات:
 									</p>
 									<ul className="space-y-1">
-										{platform.features.map(
+										{safePlatform.features.map(
 											(feature: string, index: number) => (
 												<li
 													key={index}
@@ -72,13 +74,13 @@ export function ConnectionModal({
 									</ul>
 								</div>
 							)}
-							{platform.permissions && platform.permissions.length > 0 && (
+							{safePlatform.permissions && safePlatform.permissions.length > 0 && (
 								<div>
 									<p className="mb-2 text-sm font-medium text-content">
 										مجوزهای مورد نیاز:
 									</p>
 									<ul className="space-y-1">
-										{platform.permissions.map(
+										{safePlatform.permissions.map(
 											(permission: string, index: number) => (
 												<li
 													key={index}
@@ -109,9 +111,9 @@ export function ConnectionModal({
 						}
 						className="flex-2 h-9 text-sm"
 						rounded={'2xl'}
-						variant={platform.connected ? 'danger' : 'primary'}
+						variant={safePlatform.connected ? 'danger' : 'primary'}
 					>
-						{platform.connected ? 'قطع اتصال' : 'تایید و شروع اتصال'}
+						{safePlatform.connected ? 'قطع اتصال' : 'تایید و شروع اتصال'}
 					</Button>
 					<Button
 						size="sm"

--- a/src/layouts/setting/tabs/general/components/select-city.tsx
+++ b/src/layouts/setting/tabs/general/components/select-city.tsx
@@ -113,13 +113,11 @@ export function SelectCity({ size }: Prop) {
 					</div>
 				)}
 			</div>
-			{showAuthModal && (
-				<AuthRequiredModal
-					isOpen={showAuthModal}
-					onClose={() => setShowAuthModal(!showAuthModal)}
-					message="برای انتخاب شهر، لطفا وارد حساب کاربری خود شوید."
-				/>
-			)}
+			<AuthRequiredModal
+				isOpen={showAuthModal}
+				onClose={() => setShowAuthModal(!showAuthModal)}
+				message="برای انتخاب شهر، لطفا وارد حساب کاربری خود شوید."
+			/>
 			<Modal
 				isOpen={isModalOpen}
 				onClose={() => {

--- a/src/layouts/setting/tabs/wallpapers/components/coin-purchase-modal.tsx
+++ b/src/layouts/setting/tabs/wallpapers/components/coin-purchase-modal.tsx
@@ -1,3 +1,4 @@
+import { useLastDefined } from '@/hooks/use-delayed-unmount'
 import { callEvent } from '@/common/utils/call-event'
 import type { Wallpaper } from '@/common/wallpaper.interface'
 import { Button, Modal } from '@/components/ui'
@@ -21,7 +22,8 @@ export function CoinPurchaseModal({
 	isPurchasing = false,
 }: CoinPurchaseModalProps) {
 	const { isAuthenticated } = useAuth()
-	if (!wallpaper) return null
+	const safeWallpaper = useLastDefined(wallpaper)
+	if (!safeWallpaper) return null
 
 	const onLogin = () => {
 		onClose()
@@ -40,20 +42,20 @@ export function CoinPurchaseModal({
 		>
 			<div className="space-y-4">
 				<div className="relative overflow-hidden rounded-lg aspect-video">
-					{wallpaper.type === 'IMAGE' ? (
+					{safeWallpaper.type === 'IMAGE' ? (
 						<img
-							src={wallpaper.previewSrc}
-							alt={wallpaper.name || 'Wallpaper'}
+							src={safeWallpaper.previewSrc}
+							alt={safeWallpaper.name || 'Wallpaper'}
 							className="object-cover w-full h-full rounded"
 						/>
 					) : (
 						<HoverPlayVideo
 							videoSrc={
-								wallpaper.previewVideoSrc || //demo video
-								wallpaper.src ||
-								wallpaper.previewSrc
+								safeWallpaper.previewVideoSrc || //demo video
+								safeWallpaper.src ||
+								safeWallpaper.previewSrc
 							}
-							posterSrc={wallpaper.previewSrc} //previewSrc is poster
+							posterSrc={safeWallpaper.previewSrc} //previewSrc is poster
 							className="object-cover w-full h-full transition-opacity rounded-xl"
 							onClick={(e) => {
 								e.stopPropagation()
@@ -65,10 +67,10 @@ export function CoinPurchaseModal({
 				<div className="space-y-3">
 					<div className="flex items-center justify-between">
 						<h3 className="text-lg font-semibold text-content">
-							{wallpaper.name || 'تصویر تصویر زمینه'}
+							{safeWallpaper.name || 'تصویر تصویر زمینه'}
 						</h3>
 						<UserCoin
-							coins={wallpaper.coin || 0}
+							coins={safeWallpaper.coin || 0}
 							title="قیمت این تصویر زمینه"
 						/>
 					</div>

--- a/src/layouts/widgets-manager/add-widget-modal/index.tsx
+++ b/src/layouts/widgets-manager/add-widget-modal/index.tsx
@@ -1,4 +1,3 @@
-import { useDelayedUnmount } from '@/hooks/use-delayed-unmount'
 import type React from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { Button, Modal } from '@/components/ui'
@@ -22,7 +21,6 @@ import { AddWidgetPreview } from './preview'
 import { AddWidgetActions } from './actions'
 
 export function AddWidgetModal({ isOpen, editTarget, onClose }: AddWidgetModalProps) {
-	const shouldRender = useDelayedUnmount(isOpen, 300)
 	const { isVip } = useAuth()
 	const { isWidgetVipOnly, isVariantVipOnly, isSizeVipOnly, maxFreeWidgets } =
 		useWidgetVipResolver()
@@ -196,10 +194,6 @@ export function AddWidgetModal({ isOpen, editTarget, onClose }: AddWidgetModalPr
 		if (activeCategory === 'all') return allDefinitions
 		return allDefinitions.filter((def) => def.category === activeCategory)
 	}, [allDefinitions, activeCategory])
-
-	if (!shouldRender) {
-		return null
-	}
 
 	const previewSize = selectedSize
 

--- a/src/layouts/widgets-manager/add-widget-modal/index.tsx
+++ b/src/layouts/widgets-manager/add-widget-modal/index.tsx
@@ -1,3 +1,4 @@
+import { useDelayedUnmount } from '@/hooks/use-delayed-unmount'
 import type React from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { Button, Modal } from '@/components/ui'
@@ -21,6 +22,7 @@ import { AddWidgetPreview } from './preview'
 import { AddWidgetActions } from './actions'
 
 export function AddWidgetModal({ isOpen, editTarget, onClose }: AddWidgetModalProps) {
+	const shouldRender = useDelayedUnmount(isOpen, 300)
 	const { isVip } = useAuth()
 	const { isWidgetVipOnly, isVariantVipOnly, isSizeVipOnly, maxFreeWidgets } =
 		useWidgetVipResolver()
@@ -195,7 +197,7 @@ export function AddWidgetModal({ isOpen, editTarget, onClose }: AddWidgetModalPr
 		return allDefinitions.filter((def) => def.category === activeCategory)
 	}, [allDefinitions, activeCategory])
 
-	if (!isOpen) {
+	if (!shouldRender) {
 		return null
 	}
 

--- a/src/layouts/widgets-settings/widget-settings-modal.tsx
+++ b/src/layouts/widgets-settings/widget-settings-modal.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useLastDefined } from '@/hooks/use-delayed-unmount'
 import { Modal } from '@/components/ui'
 import { PetSettings } from '../widgetify-card/pets/setting/pet-setting'
 import { RssFeedSetting } from '../widgets/news/rss-feed-setting'
@@ -71,24 +72,25 @@ export function WidgetSettingsModal({
 			: null)
 
 	const activeSettingConfig = settingKey ? WIDGET_SETTING_MODALS[settingKey] : null
+	const lastSettingConfig = useLastDefined(activeSettingConfig)
 	const handleCloseSetting = onCloseSetting || onClose
 
 	return (
 		<>
-			{isManageOpen && <AddWidgetModal isOpen={isManageOpen} onClose={onClose} />}
+			<AddWidgetModal isOpen={isManageOpen} onClose={onClose} />
 
-			{activeSettingConfig && (
-				<Modal
-					isOpen={true}
-					onClose={handleCloseSetting}
-					title={activeSettingConfig.title}
-					size={activeSettingConfig.size}
-					direction="rtl"
-					closeOnBackdropClick
-				>
-					<activeSettingConfig.Component {...({ instanceId, size } as any)} />
-				</Modal>
-			)}
+			<Modal
+				isOpen={!!activeSettingConfig}
+				onClose={handleCloseSetting}
+				title={lastSettingConfig?.title}
+				size={lastSettingConfig?.size}
+				direction="rtl"
+				closeOnBackdropClick
+			>
+				{lastSettingConfig && (
+					<lastSettingConfig.Component {...({ instanceId, size } as any)} />
+				)}
+			</Modal>
 		</>
 	)
 }

--- a/src/layouts/widgets-settings/widget-settings-modal.tsx
+++ b/src/layouts/widgets-settings/widget-settings-modal.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { useLastDefined } from '@/hooks/use-delayed-unmount'
-import { Modal } from '@/components/ui'
+import { useDelayedUnmount, useLastDefined } from '@/hooks/use-delayed-unmount'
+import { MODAL_EXIT_MS, Modal } from '@/components/ui'
 import { PetSettings } from '../widgetify-card/pets/setting/pet-setting'
 import { RssFeedSetting } from '../widgets/news/rss-feed-setting'
 import { WeatherSetting } from '../widgets/weather/weather-setting'
@@ -73,13 +73,18 @@ export function WidgetSettingsModal({
 
 	const activeSettingConfig = settingKey ? WIDGET_SETTING_MODALS[settingKey] : null
 	const lastSettingConfig = useLastDefined(activeSettingConfig)
+	const shouldMountManager = useDelayedUnmount(isManageOpen, MODAL_EXIT_MS)
+	const shouldMountSetting = useDelayedUnmount(!!activeSettingConfig, MODAL_EXIT_MS)
 	const handleCloseSetting = onCloseSetting || onClose
 
 	return (
 		<>
-			<AddWidgetModal isOpen={isManageOpen} onClose={onClose} />
+			{shouldMountManager && (
+				<AddWidgetModal isOpen={isManageOpen} onClose={onClose} />
+			)}
 
-			<Modal
+			{shouldMountSetting && (
+				<Modal
 				isOpen={!!activeSettingConfig}
 				onClose={handleCloseSetting}
 				title={lastSettingConfig?.title}
@@ -91,6 +96,7 @@ export function WidgetSettingsModal({
 					<lastSettingConfig.Component {...({ instanceId, size } as any)} />
 				)}
 			</Modal>
+			)}
 		</>
 	)
 }

--- a/src/layouts/widgets/todos/todo.item.tsx
+++ b/src/layouts/widgets/todos/todo.item.tsx
@@ -260,8 +260,7 @@ export function TodoItem({
 				</div>
 			)}
 
-			{showConfirmation && (
-				<ConfirmationModal
+			<ConfirmationModal
 					isOpen={showConfirmation}
 					onClose={() => setShowConfirmation(false)}
 					onConfirm={onConfirmDelete}
@@ -270,7 +269,6 @@ export function TodoItem({
 					variant="danger"
 					title="حذف این تسک؟"
 				/>
-			)}
 		</div>
 	)
 }

--- a/src/layouts/widgets/tools/tools.layout.tsx
+++ b/src/layouts/widgets/tools/tools.layout.tsx
@@ -1,5 +1,6 @@
 import { Motion as motion } from "@/common/motion";
 import React, { Suspense, useEffect, useState } from 'react'
+import { useLastDefined } from '@/hooks/use-delayed-unmount'
 import Analytics from '@/analytics'
 import { getFromStorage, setToStorage } from '@/common/storage'
 import { useDate } from '@/context/date.context'
@@ -61,6 +62,7 @@ interface ToolsLayoutProps {
 export const ToolsLayout: React.FC<ToolsLayoutProps> = ({ size = { w: 2, h: 3 } }) => {
 	const [activeTab, setActiveTab] = useState<ToolsTabType | null>(null)
 	const [activeModalTool, setActiveModalTool] = useState<ToolsTabType | null>(null)
+	const lastModalTool = useLastDefined(activeModalTool)
 	const { selectedDate } = useDate()
 
 	const onTabClick = (tab: ToolsTabType) => {
@@ -97,14 +99,13 @@ export const ToolsLayout: React.FC<ToolsLayoutProps> = ({ size = { w: 2, h: 3 } 
 					<ToolsCompactRow onSelectTab={onCompactToolClick} />
 				</WidgetContainer>
 
-				{activeModalTool && (
-					<Modal
+				<Modal
 						isOpen={!!activeModalTool}
 						onClose={() => setActiveModalTool(null)}
 						title={
-							activeModalTool === 'pomodoro'
+							lastModalTool === 'pomodoro'
 								? 'تایمر پومودورو'
-								: activeModalTool === 'religious-time'
+								: lastModalTool === 'religious-time'
 									? 'اوقات شرعی'
 									: 'تبدیل ارز'
 						}
@@ -112,14 +113,13 @@ export const ToolsLayout: React.FC<ToolsLayoutProps> = ({ size = { w: 2, h: 3 } 
 						direction="rtl"
 					>
 						<Suspense>
-							{activeModalTool === 'religious-time' && (
+							{lastModalTool === 'religious-time' && (
 								<ReligiousTime currentDate={selectedDate} />
 							)}
-							{activeModalTool === 'pomodoro' && <PomodoroTimer />}
-							{activeModalTool === 'currency-converter' && <CurrencyConverter />}
+							{lastModalTool === 'pomodoro' && <PomodoroTimer />}
+							{lastModalTool === 'currency-converter' && <CurrencyConverter />}
 						</Suspense>
 					</Modal>
-				)}
 			</>
 		)
 	}

--- a/src/layouts/widgets/wigi-arz/components/currency-modal.tsx
+++ b/src/layouts/widgets/wigi-arz/components/currency-modal.tsx
@@ -27,21 +27,8 @@ export const CurrencyModalComponent = ({
 	currencyColorMode,
 }: CurrencyModalComponentProps) => {
 	const [showConverter, setShowConverter] = useState(false)
-	const [isVisible, setIsVisible] = useState(false)
 	const [currencyAmount, setCurrencyAmount] = useState<number>(1)
 	const [tomanAmount, setTomanAmount] = useState<number>(0)
-
-	useEffect(() => {
-		let timerId: NodeJS.Timeout
-		if (isModalOpen) {
-			timerId = setTimeout(() => {
-				setIsVisible(true)
-			}, 50)
-		} else {
-			setIsVisible(false)
-		}
-		return () => clearTimeout(timerId)
-	}, [isModalOpen])
 
 	useEffect(() => {
 		if (isModalOpen && currency?.rialPrice) {
@@ -85,9 +72,7 @@ export const CurrencyModalComponent = ({
 	return (
 		<Modal isOpen={isModalOpen} onClose={toggleCurrencyModal} size="sm">
 			<div
-				className={`relative p-8 flex flex-col items-center justify-center space-y-2 transition-all duration-300 ease-out ${
-					isVisible ? 'scale-100 opacity-100' : 'scale-95 opacity-0'
-				}`}
+				className="relative flex flex-col items-center justify-center p-8 space-y-2"
 			>
 				<div className="relative transition-transform duration-200 ease-out">
 					<img

--- a/src/pages/home/home.page.tsx
+++ b/src/pages/home/home.page.tsx
@@ -1,3 +1,5 @@
+import { useDelayedUnmount } from '@/hooks/use-delayed-unmount'
+import { MODAL_EXIT_MS } from '@/components/ui'
 import { HomeContentCustom } from './ui/home-content-custom'
 import { getFromStorage, setToStorage } from '@/common/storage'
 import { ConfigKey } from '@/common/constant/config.key'
@@ -58,6 +60,7 @@ const steps: Step[] = [
 export function HomePage() {
 	const [showWelcomeModal, setShowWelcomeModal] = useState(false)
 	const [showReleaseNotes, setShowReleaseNotes] = useState(false)
+	const shouldMountReleaseNotes = useDelayedUnmount(showReleaseNotes, MODAL_EXIT_MS)
 	const [showTour, setShowTour] = useState(false)
 	const [appIsReady, setAppIsReady] = useState(false)
 
@@ -139,11 +142,13 @@ export function HomePage() {
 				onEvent={onDoneTour}
 			/>
 
-			<UpdateReleaseNotesModal
-				isOpen={showReleaseNotes}
-				onClose={() => onCloseReleaseNotes()}
-				counterValue={2}
-			/>
+			{shouldMountReleaseNotes && (
+				<UpdateReleaseNotesModal
+					isOpen={showReleaseNotes}
+					onClose={() => onCloseReleaseNotes()}
+					counterValue={2}
+				/>
+			)}
 		</>
 	)
 }

--- a/src/pages/home/home.page.tsx
+++ b/src/pages/home/home.page.tsx
@@ -139,13 +139,11 @@ export function HomePage() {
 				onEvent={onDoneTour}
 			/>
 
-			{showReleaseNotes && (
-				<UpdateReleaseNotesModal
-					isOpen={showReleaseNotes}
-					onClose={() => onCloseReleaseNotes()}
-					counterValue={2}
-				/>
-			)}
+			<UpdateReleaseNotesModal
+				isOpen={showReleaseNotes}
+				onClose={() => onCloseReleaseNotes()}
+				counterValue={2}
+			/>
 		</>
 	)
 }

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -12,7 +12,8 @@ import { NavbarLayout } from '@/layouts/navbar/navbar.layout'
 import { WidgetTabKeys } from '@/layouts/widgets-settings/constant/tab-keys'
 import { WidgetSettingsModal } from '@/layouts/widgets-settings/widget-settings-modal'
 import { Page, usePage } from '@/context/page.context'
-import { AnimatePresence, motion, MotionConfig } from 'framer-motion'
+import { MotionConfig } from 'framer-motion'
+import { Motion as motion, Presence } from '@/common/motion'
 import { AuthRequiredModal } from '@/components/auth/auth-required-modal'
 import { MiniAppPage } from './mini-apps/mini-app.page'
 import { ExplorerPage } from './explorer/explorer.page'
@@ -100,7 +101,7 @@ function Main() {
 				<WidgetVisibilityProvider>
 					<NavbarLayout />
 
-					<AnimatePresence mode="wait">
+					<Presence mode="wait">
 						<motion.div
 							key={page}
 							initial={{ opacity: 0 }}
@@ -120,7 +121,7 @@ function Main() {
 								<MiniAppPage />
 							)}
 						</motion.div>
-					</AnimatePresence>
+					</Presence>
 					<WidgetSettingsModal
 						isOpen={showManageWidgets}
 						onClose={() => setShowManageWidgets(false)}

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -133,12 +133,10 @@ function Main() {
 				</WidgetVisibilityProvider>
 			</FreeWidgetProvider>
 
-			{showAuthRequired && (
-				<AuthRequiredModal
-					isOpen={showAuthRequired}
-					onClose={() => setAuthRequired(false)}
-				/>
-			)}
+			<AuthRequiredModal
+				isOpen={showAuthRequired}
+				onClose={() => setAuthRequired(false)}
+			/>
 		</MotionConfig>
 	)
 }


### PR DESCRIPTION
## Problem

Opening was animated but closing snapped shut, for modals, the navbar dropdowns and the navbar itself. Several earlier attempts had not fixed it.

## Root cause

daisyUI v5 already ships a complete enter **and** exit system for modals:

```css
.modal { visibility: hidden; opacity: 0;
         transition: visibility .3s allow-discrete, opacity .1s ease-out }
.modal[open] { visibility: visible; opacity: 1 }

@starting-style { .modal[open] { opacity: 0 } }
```

`@starting-style` is why **opening** looked fine even though the dialog was mounted fresh. **Closing** needs the element to stay in the DOM so the `visibility` transition can run — and `Modal` was doing:

```tsx
if (!isOpen) return null
```

so the whole `<dialog>` was torn out of the DOM in the same frame. The exit transition never got a chance to run.

That also explains why the previous attempts failed: each one added another **entry** animation at the wrong layer — `animate-modal-in` with a hand written keyframe, a dead `opacity-100` on the dialog, `transition-all` on the box fighting daisyUI's own transition, and a `setTimeout` driven fade inside the currency modal whose closing branch could never paint.

## Modal

- Stop unmounting on close. The portal and dialog stay mounted and only the `open` attribute toggles, so daisyUI animates both directions.
- Render the dialog closed for one frame before opening. `.modal-box` has **no** `@starting-style`, so a dialog that mounts already open skipped the slide up entirely. This is what made the widget manager open differently from every other modal. Now all 57 open identically regardless of how their parent renders them.
- Drop `animate-modal-in`, the dead opacity classes and the conflicting `transition-all`, and remove the now unused keyframe.
- Unmount children shortly after closing so heavy content is not kept alive by the always mounted dialog.

## Dropdown and popovers

Now use the `Portal` + `Presence` + `exit` pattern that `bottom-sheet` already used, with the condition **inside** `Presence`.

The search history panel, the browser bookmark popover and the user card were relying on `animate-in` / `fade-in` / `zoom-in` classes from `tailwindcss-animate` — **which is not installed**. Those classes compile to nothing, so those three had no animation at all, in either direction.

## Navbar

It had no `duration-*` class, so it ran on Tailwind's 150ms default and faded out before the slide was visible. The reopen handle mounted with no transition at all and masked what little movement there was. Both now share one 500ms curve.

## Call sites

Converts the ones that destroyed the modal before it could animate out: parent level `&&` gates, and modals that returned null when their data prop cleared. Content is held through the exit via `useLastDefined` so it does not blank mid animation.

## Settings tabs

The account tab was the only one of eleven with its own entry animation — a vertical 300ms slide stacked on top of the tab manager's horizontal 200ms one. It now skips the mount animation and keeps the crossfade between the login form and the profile.

## Not included

`voice-search.portal.tsx` calls `startVoiceSearch()` in a mount effect, so making it always mounted would open the microphone unprompted. Left alone deliberately.

About eight modals are still gated by their parent (habit detail, habit share, avatar crop, add bookmark). Their **opening** is now correct and consistent thanks to the one frame change; their closing still snaps. One of them renders a dynamic component, so converting it needs more care.

## Testing

`npm test`, `npm run compile`, `biome check` and `npm run build` all pass. Verified in the built CSS that `modal-in` is gone and daisyUI's transitions are untouched.
