### PR TITLE
fix(pets): stop the pet teleporting across the widget when it climbs

### DIFF
--- a/src/layouts/widgetify-card/pets/__tests__/pet-movement.test.ts
+++ b/src/layouts/widgetify-card/pets/__tests__/pet-movement.test.ts
@@ -155,6 +155,41 @@ describe('clampToBounds', () => {
 	})
 })
 
+describe('narrow containers', () => {
+	it('keeps a usable track when the container is barely wider than the sprite', () => {
+		const b = bounds(80, 64)
+		expect(b.maxX).toBeGreaterThanOrEqual(b.minX)
+		expect(clampToBounds({ x: 500, y: 0 }, b).x).toBe(b.maxX)
+	})
+
+	it('pulls a pet left behind by a shrinking container back into view', () => {
+		const wide = bounds(600, 64)
+		const narrow = bounds(160, 64)
+
+		const restingFarRight = { x: wide.maxX, y: 0 }
+		expect(restingFarRight.x).toBeGreaterThan(narrow.maxX)
+
+		const rescued = clampToBounds(restingFarRight, narrow)
+		expect(rescued.x).toBe(narrow.maxX)
+		expect(rescued.x + SPRITE_WIDTH).toBeLessThanOrEqual(160)
+	})
+
+	it('pulls a climbing pet down when the container gets shorter', () => {
+		const tall = bounds(600, 200)
+		const short = bounds(600, 40)
+
+		const midClimb = { x: 100, y: tall.maxY }
+		expect(clampToBounds(midClimb, short).y).toBe(short.maxY)
+	})
+
+	it('does not produce a position outside a zero sized container', () => {
+		const b = bounds(0, 0)
+		const clamped = clampToBounds({ x: 999, y: 999 }, b)
+		expect(clamped.x).toBe(b.minX)
+		expect(clamped.y).toBe(0)
+	})
+})
+
 describe('isNearWall', () => {
 	it('detects both walls', () => {
 		const b = bounds()

--- a/src/layouts/widgetify-card/pets/__tests__/pet-movement.test.ts
+++ b/src/layouts/widgetify-card/pets/__tests__/pet-movement.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'bun:test'
+import {
+	clampToBounds,
+	directionTowardWall,
+	frameScale,
+	getMovementBounds,
+	isNearWall,
+	pickClimbWall,
+	stepWalk,
+} from '../core/pet-movement'
+
+const SPRITE_WIDTH = 50
+const SPRITE_HEIGHT = 32
+
+function bounds(containerWidth = 200, containerHeight = 64, maxHeight = 100) {
+	return getMovementBounds(
+		containerWidth,
+		containerHeight,
+		SPRITE_WIDTH,
+		SPRITE_HEIGHT,
+		maxHeight
+	)
+}
+
+describe('getMovementBounds', () => {
+	it('subtracts the sprite width from the horizontal bound, not its height', () => {
+		const b = bounds(200)
+		expect(b.maxX).toBe(140)
+		expect(b.minX).toBe(10)
+	})
+
+	it('keeps the pet fully inside the container horizontally', () => {
+		const b = bounds(200)
+		expect(b.maxX + SPRITE_WIDTH).toBeLessThanOrEqual(200)
+	})
+
+	it('caps the climb height by the container height', () => {
+		expect(bounds(200, 64, 100).maxY).toBe(32)
+		expect(bounds(200, 64, 20).maxY).toBe(20)
+	})
+
+	it('never returns negative bounds for a collapsed container', () => {
+		const b = bounds(0, 0)
+		expect(b.maxX).toBeGreaterThanOrEqual(b.minX)
+		expect(b.maxY).toBe(0)
+	})
+
+	it('never returns negative bounds for a container smaller than the sprite', () => {
+		const b = bounds(30, 10)
+		expect(b.maxX).toBeGreaterThanOrEqual(b.minX)
+		expect(b.maxY).toBe(0)
+	})
+})
+
+describe('pickClimbWall', () => {
+	it('picks the right wall when the pet just bounced off it', () => {
+		const b = bounds()
+		expect(pickClimbWall(b.maxX, b)).toBe(b.maxX)
+	})
+
+	it('picks the left wall when the pet just bounced off it', () => {
+		const b = bounds()
+		expect(pickClimbWall(b.minX, b)).toBe(b.minX)
+	})
+
+	it('does not teleport a pet that bounced off the right wall', () => {
+		const b = bounds()
+		const afterBounce = stepWalk({ x: b.maxX - 1, y: 0 }, 1, 3.5, 1.5, b)
+
+		expect(afterBounce.position.x).toBe(b.maxX)
+		expect(afterBounce.direction).toBe(-1)
+		expect(pickClimbWall(afterBounce.position.x, b)).toBe(b.maxX)
+	})
+
+	it('does not teleport a pet that bounced off the left wall', () => {
+		const b = bounds()
+		const afterBounce = stepWalk({ x: b.minX + 1, y: 0 }, -1, 3.5, 1.5, b)
+
+		expect(afterBounce.position.x).toBe(b.minX)
+		expect(afterBounce.direction).toBe(1)
+		expect(pickClimbWall(afterBounce.position.x, b)).toBe(b.minX)
+	})
+
+	it('always resolves to the nearer wall across the whole track', () => {
+		const b = bounds()
+		const middle = (b.minX + b.maxX) / 2
+
+		for (let x = b.minX; x <= b.maxX; x++) {
+			const wall = pickClimbWall(x, b)
+			expect(wall === b.minX || wall === b.maxX).toBe(true)
+			if (x < middle) expect(wall).toBe(b.minX)
+			if (x > middle) expect(wall).toBe(b.maxX)
+		}
+	})
+})
+
+describe('directionTowardWall', () => {
+	it('faces the pet at the wall it climbs', () => {
+		const b = bounds()
+		expect(directionTowardWall(b.maxX, b)).toBe(1)
+		expect(directionTowardWall(b.minX, b)).toBe(-1)
+	})
+})
+
+describe('stepWalk', () => {
+	it('turns around at the right wall without overshooting', () => {
+		const b = bounds()
+		const result = stepWalk({ x: b.maxX - 1, y: 0 }, 1, 3.5, 1.5, b)
+		expect(result.position.x).toBe(b.maxX)
+		expect(result.direction).toBe(-1)
+	})
+
+	it('turns around at the left wall without overshooting', () => {
+		const b = bounds()
+		const result = stepWalk({ x: b.minX + 1, y: 0 }, -1, 3.5, 1.5, b)
+		expect(result.position.x).toBe(b.minX)
+		expect(result.direction).toBe(1)
+	})
+
+	it('keeps the pet inside the track over a long walk', () => {
+		const b = bounds()
+		let position = { x: b.minX, y: 0 }
+		let direction = 1
+
+		for (let i = 0; i < 500; i++) {
+			const result = stepWalk(position, direction, 3.5, 1.5, b)
+			position = result.position
+			direction = result.direction
+			expect(position.x).toBeGreaterThanOrEqual(b.minX)
+			expect(position.x).toBeLessThanOrEqual(b.maxX)
+		}
+	})
+
+	it('pulls the pet back down to the floor while walking', () => {
+		const b = bounds()
+		const result = stepWalk({ x: 50, y: 10 }, 1, 1, 1.5, b)
+		expect(result.position.y).toBe(8.5)
+	})
+
+	it('never pushes the pet below the floor', () => {
+		const b = bounds()
+		const result = stepWalk({ x: 50, y: 0.5 }, 1, 1, 1.5, b)
+		expect(result.position.y).toBe(0)
+	})
+})
+
+describe('clampToBounds', () => {
+	it('brings out of range positions back inside', () => {
+		const b = bounds()
+		expect(clampToBounds({ x: -100, y: -100 }, b)).toEqual({ x: b.minX, y: 0 })
+		expect(clampToBounds({ x: 9999, y: 9999 }, b)).toEqual({
+			x: b.maxX,
+			y: b.maxY,
+		})
+	})
+})
+
+describe('isNearWall', () => {
+	it('detects both walls', () => {
+		const b = bounds()
+		expect(isNearWall(b.minX, b)).toBe(true)
+		expect(isNearWall(b.maxX, b)).toBe(true)
+		expect(isNearWall((b.minX + b.maxX) / 2, b)).toBe(false)
+	})
+})
+
+describe('frameScale', () => {
+	it('is 1 at the reference frame time', () => {
+		expect(frameScale(16.67)).toBeCloseTo(1, 5)
+	})
+
+	it('keeps travel per second stable across refresh rates', () => {
+		const at60 = frameScale(16.67) * 60
+		const at144 = frameScale(6.94) * 144
+		expect(Math.abs(at60 - at144)).toBeLessThan(1)
+	})
+
+	it('guards against bad or huge deltas', () => {
+		expect(frameScale(0)).toBe(1)
+		expect(frameScale(Number.NaN)).toBe(1)
+		expect(frameScale(10000)).toBe(3)
+	})
+})

--- a/src/layouts/widgetify-card/pets/components/pet-tooltip.tsx
+++ b/src/layouts/widgetify-card/pets/components/pet-tooltip.tsx
@@ -3,6 +3,7 @@ interface PetTooltipProps {
 	content: string | React.ReactNode
 	emoji?: string
 	isAnimation?: boolean
+	placement?: 'top' | 'bottom'
 }
 
 export const PetTooltip: React.FC<PetTooltipProps> = ({
@@ -10,15 +11,20 @@ export const PetTooltip: React.FC<PetTooltipProps> = ({
 	content,
 	emoji,
 	isAnimation = false,
+	placement = 'top',
 }) => {
 	return (
 		<div
-			className="absolute -translate-x-1/2 -top-8 left-1/2"
+			className={`absolute left-1/2 ${placement === 'top' ? '-top-8' : '-bottom-8'}`}
 			style={{
-				transform: `scaleX(${direction})`,
-				animation: isAnimation ? 'fadeInUp 0.3s ease-out' : undefined,
+				transform: `translateX(-50%) scaleX(${direction})`,
 			}}
 		>
+			<div
+				style={{
+					animation: isAnimation ? 'fadeInUp 0.3s ease-out' : undefined,
+				}}
+			>
 			<div
 				className={
 					'relative bg-gradient-to-r  px-3 py-1.5 rounded-md text-xs whitespace-nowrap shadow-lg bg-content after:content-[""] after:absolute after:top-full after:left-1/2 after:-translate-x-1/2 after:border-l-[6px] after:border-r-[6px] after:border-t-[6px] after:border-l-transparent after:border-r-transparent after:border-t-base-300'
@@ -44,6 +50,7 @@ export const PetTooltip: React.FC<PetTooltipProps> = ({
 					)}
 					<span className={'font-medium text-content'}>{content}</span>
 				</div>
+			</div>
 			</div>
 
 			{isAnimation && (

--- a/src/layouts/widgetify-card/pets/core/base-pet.tsx
+++ b/src/layouts/widgetify-card/pets/core/base-pet.tsx
@@ -117,7 +117,7 @@ export const BasePetContainer: React.FC<BasePetContainerProps> = ({
 		<div
 			ref={containerRef}
 			className={cn(
-				'absolute hidden w-full h-16 overflow-hidden -bottom-2 md:flex',
+				'absolute flex w-full h-16 overflow-hidden -bottom-2',
 				className
 			)}
 			style={{
@@ -688,6 +688,20 @@ export function useBasePetLogic({
 		frameId = requestAnimationFrame(loop)
 		return () => cancelAnimationFrame(frameId)
 	}, [])
+
+	useEffect(() => {
+		const container = containerRef.current
+		if (!container) return
+
+		const observer = new ResizeObserver(() => {
+			const bounds = getBounds()
+			if (bounds.maxX <= bounds.minX && bounds.maxY <= 0) return
+			applyPosition(clampToBounds(positionRef.current, bounds))
+		})
+
+		observer.observe(container)
+		return () => observer.disconnect()
+	}, [getBounds, applyPosition])
 
 	useEffect(() => {
 		const container = containerRef.current

--- a/src/layouts/widgetify-card/pets/core/base-pet.tsx
+++ b/src/layouts/widgetify-card/pets/core/base-pet.tsx
@@ -2,6 +2,15 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { PetTooltip } from '../components/pet-tooltip'
 import { cn } from '@/common/utils/cn'
 import {
+	clampToBounds,
+	directionTowardWall,
+	frameScale,
+	getMovementBounds,
+	isNearWall,
+	pickClimbWall,
+	stepWalk,
+} from './pet-movement'
+import {
 	type CollectibleItem,
 	type PetAnimations,
 	type PetAssets,
@@ -73,7 +82,6 @@ interface BasePetContainerProps {
 	dimensions: PetDimensions
 	assets: PetAssets
 	isHungry: boolean
-	hungryLevel: number | undefined
 	className?: string
 }
 
@@ -125,7 +133,7 @@ export const BasePetContainer: React.FC<BasePetContainerProps> = ({
 					left: `${position.x}px`,
 					bottom: `${position.y}px`,
 					transform: `scaleX(${direction})`,
-					width: '50px',
+					width: `${dimensions.width}px`,
 					height: `${dimensions.size}px`,
 					zIndex: 10,
 				}}
@@ -136,12 +144,14 @@ export const BasePetContainer: React.FC<BasePetContainerProps> = ({
 						content={isHungry ? 'غذاااا بدهه' : name}
 						emoji={isHungry ? '🍽️' : undefined}
 						isAnimation={isHungry}
+						placement={position.y > 0 ? 'bottom' : 'top'}
 					/>
 				)}
 				{loadedSrcs.map((src) => (
 					<img
 						key={src}
 						src={src}
+						alt={name}
 						className="absolute inset-0 object-contain w-full h-full pointer-events-none"
 						style={{ visibility: src === currentSrc ? 'visible' : 'hidden' }}
 					/>
@@ -175,28 +185,61 @@ export function useBasePetLogic({
 	const [showName, setShowName] = useState(false)
 
 	const [collectibles, setCollectibles] = useState<CollectibleItem[]>([])
-	const [collectibleIdCounter, setCollectibleIdCounter] = useState(0)
 
-	const getMovementBounds = useCallback(() => {
-		const container = containerRef.current
-		const visibleHeight = container?.offsetHeight ?? dimensions.maxHeight
+	const positionRef = useRef<Position>({ x: 30, y: 0 })
+	const collectiblesRef = useRef<CollectibleItem[]>([])
+	const collectibleIdRef = useRef(0)
+	const climbWallXRef = useRef<number | null>(null)
+	const behaviorStateRef = useRef(behaviorState)
+	const timeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
+	const onCollectibleCollectionRef = useRef(onCollectibleCollection)
+	const onLevelDownHungryStateRef = useRef(onLevelDownHungryState)
 
-		return {
-			minX: 10,
-			maxX: (container?.offsetWidth || 300) - dimensions.size - 10,
-			minY: 0,
+	onCollectibleCollectionRef.current = onCollectibleCollection
+	onLevelDownHungryStateRef.current = onLevelDownHungryState
+	behaviorStateRef.current = behaviorState
 
-			maxY: Math.max(
-				0,
-				Math.min(dimensions.maxHeight, visibleHeight - dimensions.size)
-			),
+	const scheduleTimeout = useCallback((callback: () => void, delay: number) => {
+		const id = setTimeout(() => {
+			timeoutsRef.current.delete(id)
+			callback()
+		}, delay)
+		timeoutsRef.current.add(id)
+		return id
+	}, [])
+
+	useEffect(() => {
+		const timeouts = timeoutsRef.current
+		return () => {
+			for (const id of timeouts) {
+				clearTimeout(id)
+			}
+			timeouts.clear()
 		}
-	}, [dimensions.size, dimensions.maxHeight])
+	}, [])
 
-	const isNearWall = useCallback(() => {
-		const bounds = getMovementBounds()
-		return position.x <= bounds.minX + 5 || position.x >= bounds.maxX - 5
-	}, [getMovementBounds, position.x])
+	const applyCollectibles = useCallback((next: CollectibleItem[]) => {
+		collectiblesRef.current = next
+		setCollectibles(next)
+	}, [])
+
+	const applyPosition = useCallback((next: Position) => {
+		const prev = positionRef.current
+		if (prev.x === next.x && prev.y === next.y) return
+		positionRef.current = next
+		setPosition(next)
+	}, [])
+
+	const getBounds = useCallback(() => {
+		const container = containerRef.current
+		return getMovementBounds(
+			container?.offsetWidth || 0,
+			container?.offsetHeight || 0,
+			dimensions.width,
+			dimensions.size,
+			dimensions.maxHeight
+		)
+	}, [dimensions.width, dimensions.size, dimensions.maxHeight])
 
 	const getCurrentSpeed = useCallback(() => {
 		return action === 'run' ? dimensions.runSpeed : dimensions.walkSpeed
@@ -223,50 +266,50 @@ export function useBasePetLogic({
 	const handleClick = useCallback(
 		(e: MouseEvent) => {
 			const container = containerRef.current
-			if (container) {
-				if (collectibles.length > 2) {
-					setCollectibles([])
-					return
-				}
+			if (!container) return
 
-				const rect = container.getBoundingClientRect()
-				const clickX = e.clientX - rect.left
-				const bounds = getMovementBounds()
-				const clampedX = Math.max(bounds.minX, Math.min(bounds.maxX, clickX))
+			if (collectiblesRef.current.length > 2) {
+				applyCollectibles([])
+				return
+			}
 
-				const newCollectible: CollectibleItem = {
-					id: collectibleIdCounter,
-					x: clampedX,
-					y: -assets.collectibleSize,
-					collected: false,
-					dropping: true,
-				}
+			const rect = container.getBoundingClientRect()
+			const clickX = e.clientX - rect.left
+			const bounds = getBounds()
+			const clampedX = Math.max(bounds.minX, Math.min(bounds.maxX, clickX))
 
-				setCollectibles((prev) => [...prev, newCollectible])
-				setCollectibleIdCounter((prev) => prev + 1)
+			const newCollectible: CollectibleItem = {
+				id: collectibleIdRef.current,
+				x: clampedX,
+				y: -assets.collectibleSize,
+				collected: false,
+				dropping: true,
+			}
+			collectibleIdRef.current += 1
 
-				if (position.y === 0) {
-					if (action === 'sit' || action === 'idle') {
-						updateAction('stand')
-						setTimeout(() => {
-							updateAction('run')
-							updateBehaviorState(PetBehavior.CHASING)
-						}, 300)
-					} else {
+			applyCollectibles([...collectiblesRef.current, newCollectible])
+
+			if (positionRef.current.y === 0) {
+				if (action === 'sit' || action === 'idle') {
+					updateAction('stand')
+					scheduleTimeout(() => {
 						updateAction('run')
 						updateBehaviorState(PetBehavior.CHASING)
-					}
+					}, 300)
+				} else {
+					updateAction('run')
+					updateBehaviorState(PetBehavior.CHASING)
 				}
 			}
 		},
 		[
-			collectibleIdCounter,
 			assets.collectibleSize,
 			action,
-			position.y,
-			getMovementBounds,
+			getBounds,
 			updateAction,
 			updateBehaviorState,
+			applyCollectibles,
+			scheduleTimeout,
 		]
 	)
 
@@ -278,11 +321,12 @@ export function useBasePetLogic({
 
 			if (availableCollectibles.length === 0) return null
 
+			const currentX = positionRef.current.x
 			let nearest = availableCollectibles[0]
-			let minDistance = Math.abs(position.x - nearest.x)
+			let minDistance = Math.abs(currentX - nearest.x)
 
 			for (let i = 1; i < availableCollectibles.length; i++) {
-				const distance = Math.abs(position.x - availableCollectibles[i].x)
+				const distance = Math.abs(currentX - availableCollectibles[i].x)
 				if (distance < minDistance) {
 					minDistance = distance
 					nearest = availableCollectibles[i]
@@ -290,81 +334,97 @@ export function useBasePetLogic({
 			}
 			return nearest
 		},
-		[position.x]
+		[]
 	)
 
 	const handleCollectibleCollection = useCallback(
 		(collectedItemId: number) => {
-			setCollectibles((prevCollectibles) =>
-				prevCollectibles.map((collectible) =>
-					collectible.id === collectedItemId
-						? { ...collectible, collected: true }
-						: collectible
-				)
-			)
 			updateAction('stand')
-			if (onCollectibleCollection) {
-				onCollectibleCollection(collectedItemId)
-			}
-			setTimeout(
+			onCollectibleCollectionRef.current?.(collectedItemId)
+			scheduleTimeout(
 				() =>
-					updateAction(behaviorState === PetBehavior.CHASING ? 'run' : 'walk'),
+					updateAction(
+						behaviorStateRef.current === PetBehavior.CHASING ? 'run' : 'walk'
+					),
 				500
 			)
 		},
-		[updateAction, behaviorState]
+		[updateAction, scheduleTimeout]
 	)
 
-	const updateCollectibles = useCallback(() => {
-		setCollectibles((prevCollectibles) => {
-			let collectiblesChanged = false
+	const updateCollectibles = useCallback(
+		(scale: number) => {
+			const prevCollectibles = collectiblesRef.current
+			if (prevCollectibles.length === 0) return
+
+			const fallStep = assets.collectibleFallSpeed * scale
+			const currentX = positionRef.current.x
+			const collectRadius = dimensions.size / 1.5
+
+			let changed = false
+			let collectedId: number | null = null
+
 			const updatedCollectibles = prevCollectibles.map((collectible) => {
 				if (collectible.collected) return collectible
 
 				if (collectible.dropping) {
-					const newY = collectible.y + assets.collectibleFallSpeed
+					changed = true
+					const newY = collectible.y + fallStep
 					if (newY >= 0) {
-						collectiblesChanged = true
 						return { ...collectible, y: 0, dropping: false }
 					}
-					collectiblesChanged = true
 					return { ...collectible, y: newY }
 				}
 
-				const distance = Math.abs(collectible.x - position.x)
-				if (
-					!collectible.collected &&
-					!collectible.dropping &&
-					distance < dimensions.size / 1.5
-				) {
-					handleCollectibleCollection(collectible.id)
-
-					return collectible
+				if (collectedId === null) {
+					const distance = Math.abs(collectible.x - currentX)
+					if (distance < collectRadius) {
+						collectedId = collectible.id
+						changed = true
+						return { ...collectible, collected: true }
+					}
 				}
+
 				return collectible
 			})
 
-			if (collectiblesChanged) {
-				return updatedCollectibles
+			if (changed) {
+				applyCollectibles(updatedCollectibles)
 			}
-			return prevCollectibles
-		})
-	}, [
-		assets.collectibleFallSpeed,
-		position.x,
-		dimensions.size,
-		handleCollectibleCollection,
-	])
+
+			if (collectedId !== null) {
+				handleCollectibleCollection(collectedId)
+			}
+		},
+		[
+			assets.collectibleFallSpeed,
+			dimensions.size,
+			applyCollectibles,
+			handleCollectibleCollection,
+		]
+	)
 
 	useEffect(() => {
 		const collectedItems = collectibles.filter((c) => c.collected)
 		if (collectedItems.length > 0) {
 			const timer = setTimeout(() => {
-				setCollectibles((prev) => prev.filter((c) => !c.collected))
+				applyCollectibles(collectiblesRef.current.filter((c) => !c.collected))
 			}, 2000)
 			return () => clearTimeout(timer)
 		}
-	}, [collectibles])
+	}, [collectibles, applyCollectibles])
+
+	const startClimb = useCallback(() => {
+		const bounds = getBounds()
+		const wallX = pickClimbWall(positionRef.current.x, bounds)
+
+		climbWallXRef.current = wallX
+		setDirection(directionTowardWall(wallX, bounds))
+		setIsDescending(false)
+		updateBehaviorState(PetBehavior.CLIMBING)
+		updateAction('climb')
+		setActionTimer(randomDuration(durations.climb))
+	}, [getBounds, updateAction, updateBehaviorState, durations.climb])
 
 	const roamOrRest = useCallback(() => {
 		if (behaviorState === PetBehavior.CLIMBING) {
@@ -381,11 +441,9 @@ export function useBasePetLogic({
 
 		const random = Math.random()
 		if (behaviorState === PetBehavior.ROAMING) {
-			if (isNearWall() && random > 0.7 && animations.climb) {
-				setIsDescending(false)
-				updateBehaviorState(PetBehavior.CLIMBING)
-				updateAction('climb')
-				setActionTimer(randomDuration(durations.climb))
+			const bounds = getBounds()
+			if (isNearWall(positionRef.current.x, bounds) && random > 0.7 && animations.climb) {
+				startClimb()
 			} else {
 				updateBehaviorState(PetBehavior.RESTING)
 				const shouldSit = Math.random() > 0.5 && animations.sit
@@ -399,13 +457,12 @@ export function useBasePetLogic({
 			setActionTimer(randomDuration(shouldRun ? durations.run : durations.walk))
 		}
 
-		if (onLevelDownHungryState) {
-			onLevelDownHungryState()
-		}
+		onLevelDownHungryStateRef.current?.()
 	}, [
 		behaviorState,
 		isHungry,
-		isNearWall,
+		getBounds,
+		startClimb,
 		animations.climb,
 		animations.sit,
 		durations,
@@ -413,92 +470,91 @@ export function useBasePetLogic({
 		updateBehaviorState,
 	])
 
-	const updateBehavior = useCallback(() => {
-		const nearestCollectible = findNearestCollectible(collectibles)
+	const updateBehavior = useCallback(
+		(elapsed: number) => {
+			const nearestCollectible = findNearestCollectible(collectiblesRef.current)
 
-		if (nearestCollectible && position.y === 0) {
-			if (behaviorState !== PetBehavior.CHASING) {
-				updateBehaviorState(PetBehavior.CHASING)
-				updateAction('run')
+			if (nearestCollectible && positionRef.current.y === 0) {
+				if (behaviorState !== PetBehavior.CHASING) {
+					updateBehaviorState(PetBehavior.CHASING)
+					updateAction('run')
+				}
+				setTargetX(nearestCollectible.x)
+				setIsMovingToTarget(true)
+				return
 			}
-			setTargetX(nearestCollectible.x)
-			setIsMovingToTarget(true)
-			return
-		}
 
-		if (behaviorState === PetBehavior.CHASING) {
-			updateBehaviorState(PetBehavior.RESTING)
-			updateAction('idle')
-			setActionTimer(2000)
-			setIsMovingToTarget(false)
-			setTargetX(null)
-			return
-		}
+			if (behaviorState === PetBehavior.CHASING) {
+				updateBehaviorState(PetBehavior.RESTING)
+				updateAction('idle')
+				setActionTimer(2000)
+				setIsMovingToTarget(false)
+				setTargetX(null)
+				return
+			}
 
-		if (!isMovingToTarget && actionTimer <= 0) {
-			roamOrRest()
-		} else if (!isMovingToTarget) {
-			setActionTimer((prev) => prev - 16)
-		}
-	}, [
-		collectibles,
-		findNearestCollectible,
-		behaviorState,
-		isMovingToTarget,
-		actionTimer,
-		position.y,
-		updateAction,
-		updateBehaviorState,
-		roamOrRest,
-	])
+			if (!isMovingToTarget && actionTimer <= 0) {
+				roamOrRest()
+			} else if (!isMovingToTarget) {
+				setActionTimer((prev) => prev - elapsed)
+			}
+		},
+		[
+			findNearestCollectible,
+			behaviorState,
+			isMovingToTarget,
+			actionTimer,
+			updateAction,
+			updateBehaviorState,
+			roamOrRest,
+		]
+	)
 
 	const movePet = useCallback(
-		(currentPosition: Position, currentDirection: number) => {
-			const bounds = getMovementBounds()
-			let newX = currentPosition.x + currentDirection * getCurrentSpeed()
-			let newDirection = currentDirection
+		(currentPosition: Position, currentDirection: number, scale: number) => {
+			const bounds = getBounds()
+			const result = stepWalk(
+				currentPosition,
+				currentDirection,
+				getCurrentSpeed() * scale,
+				FALL_SPEED * scale,
+				bounds
+			)
 
-			if (newX >= bounds.maxX) {
-				newDirection = -1
-				newX = bounds.maxX
-			} else if (newX <= bounds.minX) {
-				newDirection = 1
-				newX = bounds.minX
+			if (result.direction !== currentDirection) {
+				setDirection(result.direction)
 			}
-			if (newDirection !== currentDirection) {
-				setDirection(newDirection)
-			}
-			const newY =
-				currentPosition.y > 0 ? Math.max(0, currentPosition.y - FALL_SPEED) : 0
-			return { x: newX, y: newY }
+
+			return result.position
 		},
-		[getMovementBounds, getCurrentSpeed]
+		[getBounds, getCurrentSpeed]
 	)
 
 	const moveToTarget = useCallback(
-		(currentPosition: Position) => {
+		(currentPosition: Position, scale: number) => {
 			if (targetX === null) return currentPosition
 
-			const bounds = getMovementBounds()
+			const bounds = getBounds()
 			const delta = targetX - currentPosition.x
 			const distance = Math.abs(delta)
-			const speed = action === 'run' ? dimensions.runSpeed : dimensions.walkSpeed
+			const speed =
+				(action === 'run' ? dimensions.runSpeed : dimensions.walkSpeed) * scale
 
 			if (distance <= speed) {
 				setIsMovingToTarget(false)
 				setTargetX(null)
 
 				if (behaviorState === PetBehavior.CHASING) {
-					const nextCollectible = findNearestCollectible(collectibles)
+					const nextCollectible = findNearestCollectible(collectiblesRef.current)
 					if (!nextCollectible) {
 						updateAction('idle')
 						updateBehaviorState(PetBehavior.RESTING)
-					} else {
 					}
 				} else {
 					updateAction('idle')
 				}
-				return { x: targetX, y: currentPosition.y }
+
+				return clampToBounds({ x: targetX, y: currentPosition.y }, bounds)
 			}
 
 			const newDirection = delta > 0 ? 1 : -1
@@ -518,9 +574,8 @@ export function useBasePetLogic({
 			dimensions.runSpeed,
 			dimensions.walkSpeed,
 			behaviorState,
-			collectibles,
 			direction,
-			getMovementBounds,
+			getBounds,
 			findNearestCollectible,
 			updateAction,
 			updateBehaviorState,
@@ -528,13 +583,16 @@ export function useBasePetLogic({
 	)
 
 	const climbWall = useCallback(
-		(currentPosition: Position, currentDirection: number) => {
-			const bounds = getMovementBounds()
-			const wallX = currentDirection === 1 ? bounds.maxX : bounds.minX
+		(currentPosition: Position, scale: number) => {
+			const bounds = getBounds()
+			const wallX =
+				climbWallXRef.current ?? pickClimbWall(currentPosition.x, bounds)
+			const climbStep = dimensions.climbSpeed * scale
 
 			if (isDescending) {
-				const newY = currentPosition.y - dimensions.climbSpeed
+				const newY = currentPosition.y - climbStep
 				if (newY <= 0) {
+					climbWallXRef.current = null
 					setIsDescending(false)
 					updateBehaviorState(PetBehavior.RESTING)
 					updateAction(animations.stand ? 'stand' : 'idle')
@@ -544,7 +602,7 @@ export function useBasePetLogic({
 				return { x: wallX, y: newY }
 			}
 
-			const newY = Math.min(currentPosition.y + dimensions.climbSpeed, bounds.maxY)
+			const newY = Math.min(currentPosition.y + climbStep, bounds.maxY)
 			return { x: wallX, y: newY }
 		},
 		[
@@ -552,55 +610,64 @@ export function useBasePetLogic({
 			dimensions.climbSpeed,
 			durations.rest,
 			animations.stand,
-			getMovementBounds,
+			getBounds,
 			updateBehaviorState,
 			updateAction,
 		]
 	)
 
 	/** Safety net for a pet ever left with y > 0 outside an active climb. */
-	const applyGravity = useCallback((currentPosition: Position) => {
+	const applyGravity = useCallback((currentPosition: Position, scale: number) => {
 		if (currentPosition.y > 0) {
-			return { ...currentPosition, y: Math.max(0, currentPosition.y - FALL_SPEED) }
+			return {
+				...currentPosition,
+				y: Math.max(0, currentPosition.y - FALL_SPEED * scale),
+			}
 		}
 		return currentPosition
 	}, [])
 
-	const physicsUpdate = useCallback(() => {
-		updateCollectibles()
-		updateBehavior()
+	const physicsUpdate = useCallback(
+		(elapsed: number) => {
+			const scale = frameScale(elapsed)
 
-		setPosition((prevPosition) => {
-			let newPosition = { ...prevPosition }
+			updateCollectibles(scale)
+			updateBehavior(elapsed)
+
+			const prevPosition = positionRef.current
+			let newPosition = prevPosition
 
 			if (isMovingToTarget && (action === 'walk' || action === 'run')) {
-				newPosition = moveToTarget(prevPosition)
+				newPosition = moveToTarget(prevPosition, scale)
 			} else if (action === 'walk' || action === 'run') {
-				newPosition = movePet(prevPosition, direction)
+				newPosition = movePet(prevPosition, direction, scale)
 			} else if (
 				action === 'climb' &&
 				behaviorState === PetBehavior.CLIMBING &&
 				animations.climb
 			) {
-				newPosition = climbWall(prevPosition, direction)
+				newPosition = climbWall(prevPosition, scale)
 			} else if (behaviorState !== PetBehavior.CLIMBING && prevPosition.y > 0) {
-				newPosition = applyGravity(prevPosition)
+				newPosition = applyGravity(prevPosition, scale)
 			}
-			return newPosition
-		})
-	}, [
-		updateCollectibles,
-		updateBehavior,
-		isMovingToTarget,
-		action,
-		moveToTarget,
-		movePet,
-		direction,
-		behaviorState,
-		animations.climb,
-		climbWall,
-		applyGravity,
-	])
+
+			applyPosition(newPosition)
+		},
+		[
+			updateCollectibles,
+			updateBehavior,
+			isMovingToTarget,
+			action,
+			moveToTarget,
+			movePet,
+			direction,
+			behaviorState,
+			animations.climb,
+			climbWall,
+			applyGravity,
+			applyPosition,
+		]
+	)
 
 	const physicsUpdateRef = useRef(physicsUpdate)
 	physicsUpdateRef.current = physicsUpdate
@@ -610,9 +677,10 @@ export function useBasePetLogic({
 		let lastTick = performance.now()
 
 		const loop = (now: number) => {
-			if (now - lastTick >= 16) {
+			const elapsed = now - lastTick
+			if (elapsed >= 16) {
 				lastTick = now
-				physicsUpdateRef.current()
+				physicsUpdateRef.current(elapsed)
 			}
 			frameId = requestAnimationFrame(loop)
 		}

--- a/src/layouts/widgetify-card/pets/core/pet-movement.ts
+++ b/src/layouts/widgetify-card/pets/core/pet-movement.ts
@@ -1,0 +1,84 @@
+export interface Position {
+	x: number
+	y: number
+}
+
+export interface MovementBounds {
+	minX: number
+	maxX: number
+	minY: number
+	maxY: number
+}
+
+export const EDGE_PADDING = 10
+export const NEAR_WALL_THRESHOLD = 5
+export const REFERENCE_FRAME_MS = 16.67
+
+export function getMovementBounds(
+	containerWidth: number,
+	containerHeight: number,
+	spriteWidth: number,
+	spriteHeight: number,
+	maxHeight: number
+): MovementBounds {
+	const width = containerWidth || 0
+	const height = containerHeight || 0
+
+	return {
+		minX: EDGE_PADDING,
+		maxX: Math.max(EDGE_PADDING, width - spriteWidth - EDGE_PADDING),
+		minY: 0,
+		maxY: Math.max(0, Math.min(maxHeight, height - spriteHeight)),
+	}
+}
+
+export function clampToBounds(position: Position, bounds: MovementBounds): Position {
+	return {
+		x: Math.max(bounds.minX, Math.min(bounds.maxX, position.x)),
+		y: Math.max(bounds.minY, Math.min(bounds.maxY, position.y)),
+	}
+}
+
+export function isNearWall(x: number, bounds: MovementBounds): boolean {
+	return (
+		x <= bounds.minX + NEAR_WALL_THRESHOLD || x >= bounds.maxX - NEAR_WALL_THRESHOLD
+	)
+}
+
+export function pickClimbWall(x: number, bounds: MovementBounds): number {
+	const distanceToMin = Math.abs(x - bounds.minX)
+	const distanceToMax = Math.abs(bounds.maxX - x)
+	return distanceToMax < distanceToMin ? bounds.maxX : bounds.minX
+}
+
+export function directionTowardWall(wallX: number, bounds: MovementBounds): number {
+	return wallX === bounds.maxX ? 1 : -1
+}
+
+export function stepWalk(
+	position: Position,
+	direction: number,
+	speed: number,
+	fallSpeed: number,
+	bounds: MovementBounds
+): { position: Position; direction: number } {
+	let x = position.x + direction * speed
+	let nextDirection = direction
+
+	if (x >= bounds.maxX) {
+		nextDirection = -1
+		x = bounds.maxX
+	} else if (x <= bounds.minX) {
+		nextDirection = 1
+		x = bounds.minX
+	}
+
+	const y = position.y > 0 ? Math.max(0, position.y - fallSpeed) : 0
+
+	return { position: { x, y }, direction: nextDirection }
+}
+
+export function frameScale(deltaMs: number): number {
+	if (!Number.isFinite(deltaMs) || deltaMs <= 0) return 1
+	return Math.min(deltaMs / REFERENCE_FRAME_MS, 3)
+}

--- a/src/layouts/widgetify-card/pets/core/pet-types.ts
+++ b/src/layouts/widgetify-card/pets/core/pet-types.ts
@@ -1,43 +1,10 @@
 import type React from 'react'
 
-export enum PetType {
-	DOG = 'dog',
-	CHICKEN = 'chicken',
-}
-
-export enum PetColor {
-	WHITE = 'white',
-	BROWN = 'brown',
-	BLACK = 'black',
-	AKITA = 'akita',
-}
-
-export enum PetSize {
-	SMALL = 'small',
-	MEDIUM = 'medium',
-	LARGE = 'large',
-}
-
 export enum PetSpeed {
-	STILL = 0,
-	VERY_SLOW = 0.5,
 	SLOW = 1,
 	NORMAL = 1.8,
 	FAST = 2.5,
 	VERY_FAST = 3.5,
-}
-
-export enum PetState {
-	IDLE = 'idle',
-	WALK_LEFT = 'walk-left',
-	WALK_RIGHT = 'walk-right',
-	RUN_LEFT = 'run-left',
-	RUN_RIGHT = 'run-right',
-	SITTING = 'sit',
-	STANDING = 'stand',
-	CLIMBING = 'climb',
-	SWIPE = 'swipe',
-	CHASE = 'chase',
 }
 
 export enum PetBehavior {
@@ -72,6 +39,7 @@ export interface PetAnimations {
 
 export interface PetDimensions {
 	size: number
+	width: number
 	walkSpeed: number
 	runSpeed: number
 	climbSpeed: number

--- a/src/layouts/widgetify-card/pets/pet-factory.tsx
+++ b/src/layouts/widgetify-card/pets/pet-factory.tsx
@@ -41,7 +41,7 @@ export const PetFactory: React.FC<Prop> = ({ className }) => {
 		<Suspense fallback={<div></div>}>
 			<PetComponent className={className} />
 
-			<div className="absolute bottom-0 justify-center hidden left-2 md:flex">
+			<div className="absolute bottom-0 flex justify-center left-2">
 				<PetHud level={getPetHungryState(petType)?.level ?? 0} />
 			</div>
 		</Suspense>

--- a/src/layouts/widgetify-card/pets/pet-item/pet-cat.tsx
+++ b/src/layouts/widgetify-card/pets/pet-item/pet-cat.tsx
@@ -36,6 +36,7 @@ export const CatComponent = ({ className }: { className?: string }) => {
 
 	const catDimensions: PetDimensions = {
 		size: 25,
+		width: 50,
 		walkSpeed: PetSpeed.SLOW,
 		runSpeed: PetSpeed.NORMAL,
 		climbSpeed: PetSpeed.NORMAL,
@@ -88,7 +89,6 @@ export const CatComponent = ({ className }: { className?: string }) => {
 			dimensions={dimensions}
 			assets={assets}
 			isHungry={isPetHungry(PetTypes.CAT)}
-			hungryLevel={getPetHungryState(PetTypes.CAT)?.level}
 		/>
 	)
 }

--- a/src/layouts/widgetify-card/pets/pet-item/pet-chicken.tsx
+++ b/src/layouts/widgetify-card/pets/pet-item/pet-chicken.tsx
@@ -34,6 +34,7 @@ export const ChickenComponent = ({ className }: { className?: string }) => {
 
 	const chickenDimensions: PetDimensions = {
 		size: 32,
+		width: 50,
 		walkSpeed: PetSpeed.SLOW,
 		runSpeed: PetSpeed.FAST,
 		climbSpeed: 1.2,
@@ -87,7 +88,6 @@ export const ChickenComponent = ({ className }: { className?: string }) => {
 			dimensions={dimensions}
 			assets={assets}
 			isHungry={isPetHungry(PetTypes.CHICKEN)}
-			hungryLevel={getPetHungryState(PetTypes.CHICKEN)?.level}
 		/>
 	)
 }

--- a/src/layouts/widgetify-card/pets/pet-item/pet-crab.tsx
+++ b/src/layouts/widgetify-card/pets/pet-item/pet-crab.tsx
@@ -35,6 +35,7 @@ export const CrabComponent = ({ className }: { className?: string }) => {
 
 	const crabDimensions: PetDimensions = {
 		size: 32,
+		width: 50,
 		walkSpeed: PetSpeed.SLOW,
 		runSpeed: PetSpeed.NORMAL,
 		climbSpeed: 0.8,
@@ -88,7 +89,6 @@ export const CrabComponent = ({ className }: { className?: string }) => {
 			dimensions={dimensions}
 			assets={assets}
 			isHungry={isPetHungry(PetTypes.CRAB)}
-			hungryLevel={getPetHungryState(PetTypes.CRAB)?.level}
 		/>
 	)
 }

--- a/src/layouts/widgetify-card/pets/pet-item/pet-dog.tsx
+++ b/src/layouts/widgetify-card/pets/pet-item/pet-dog.tsx
@@ -37,6 +37,7 @@ export const DogComponent = ({ className }: { className?: string }) => {
 
 	const dogDimensions: PetDimensions = {
 		size: 32,
+		width: 50,
 		walkSpeed: PetSpeed.NORMAL,
 		runSpeed: PetSpeed.VERY_FAST,
 		climbSpeed: 1.2,
@@ -90,7 +91,6 @@ export const DogComponent = ({ className }: { className?: string }) => {
 			dimensions={dimensions}
 			assets={assets}
 			isHungry={isPetHungry(PetTypes.DOG_AKITA)}
-			hungryLevel={getPetHungryState(PetTypes.DOG_AKITA)?.level}
 		/>
 	)
 }

--- a/src/layouts/widgetify-card/pets/pet-item/pet-frog.tsx
+++ b/src/layouts/widgetify-card/pets/pet-item/pet-frog.tsx
@@ -4,6 +4,7 @@ import running from '@/assets/animals/frog/ghoori_run_8fps.webp'
 import swipe from '@/assets/animals/frog/ghoori_swipe_8fps.webp'
 import walking from '@/assets/animals/frog/ghoori_walk_8fps.webp'
 import walking_fast from '@/assets/animals/frog/ghoori_walk_fast_8fps.webp'
+import { useMemo } from 'react'
 import { LuBug } from 'react-icons/lu'
 import { BasePetContainer, useBasePetLogic } from '../core/base-pet'
 import {
@@ -14,6 +15,19 @@ import {
 	PetSpeed,
 } from '../core/pet-types'
 import { PetTypes, usePetContext } from '../pet.context'
+
+const COLLECTIBLE_COLORS = [
+	'#f87171',
+	'#22c55e',
+	'#d8b4fe',
+	'#fef08a',
+	'#db2777',
+	'#2dd4bf',
+	'#06b6d4',
+	'#818cf8',
+	'#bef264',
+	'#3b82f6',
+]
 
 export const FrogComponent = ({ className }: { className?: string }) => {
 	const {
@@ -35,6 +49,7 @@ export const FrogComponent = ({ className }: { className?: string }) => {
 
 	const frogDimensions: PetDimensions = {
 		size: 32,
+		width: 50,
 		walkSpeed: PetSpeed.SLOW,
 		runSpeed: PetSpeed.NORMAL,
 		climbSpeed: PetSpeed.NORMAL,
@@ -48,26 +63,14 @@ export const FrogComponent = ({ className }: { className?: string }) => {
 		climb: { min: 3000, max: 6000 },
 	}
 
-	const collectibleColors = [
-		'red-400',
-		'green-500',
-		'purple-300',
-		'yellow-200',
-		'pink-600',
-		'teal-400',
-		'cyan-500',
-		'indigo-400',
-		'lime-300',
-		'blue-500',
-	]
+
+	const collectibleColor = useMemo(
+		() => COLLECTIBLE_COLORS[Math.floor(Math.random() * COLLECTIBLE_COLORS.length)],
+		[]
+	)
 
 	const frogAssets: PetAssets = {
-		collectibleIcon: (
-			<LuBug
-				className={`text-${collectibleColors[Math.floor(Math.random() * collectibleColors.length)]}`}
-				size={24}
-			/>
-		),
+		collectibleIcon: <LuBug style={{ color: collectibleColor }} size={24} />,
 		collectibleSize: 24,
 		collectibleFallSpeed: 2,
 	}
@@ -106,7 +109,6 @@ export const FrogComponent = ({ className }: { className?: string }) => {
 			getAnimationForCurrentAction={getAnimationForCurrentAction}
 			dimensions={dimensions}
 			assets={assets}
-			hungryLevel={getPetHungryState(PetTypes.FROG)?.level}
 			isHungry={isPetHungry(PetTypes.FROG)}
 		/>
 	)

--- a/src/layouts/widgetify-card/pets/pet.context.tsx
+++ b/src/layouts/widgetify-card/pets/pet.context.tsx
@@ -1,4 +1,12 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react'
 import { getFromStorage, setToStorage } from '@/common/storage'
 import { listenEvent } from '@/common/utils/call-event'
 
@@ -67,7 +75,7 @@ export const BASE_PET_OPTIONS: PetSettings = {
 		},
 		[PetTypes.CAT]: {
 			name: 'زردآلو',
-			emoji: '🐈',
+			emoji: '🐱',
 			type: 'cat',
 			hungryState: {
 				level: 100,
@@ -86,18 +94,32 @@ export const BASE_PET_OPTIONS: PetSettings = {
 	},
 }
 
+const HUNGER_GAIN_STEPS = [10, 15, 25]
+
 const PetContext = createContext<PetSettingsContextType | undefined>(undefined)
 
 export function PetProvider({ children }: { children: React.ReactNode }) {
 	const [settings, setSettings] = useState<PetSettings>({
 		...BASE_PET_OPTIONS,
 	})
+	const pendingPersistRef = useRef<PetSettings | null>(null)
+
 	useEffect(() => {
+		const pending = pendingPersistRef.current
+		if (!pending) return
+		pendingPersistRef.current = null
+		setToStorage('pets', pending)
+	})
+
+	useEffect(() => {
+		let cancelled = false
+
 		async function load() {
-			// const storedPets = await getFromStorage('pets')
 			const storedPets = await getFromStorage('pets')
+			if (cancelled) return
+
 			if (storedPets) {
-				if (!storedPets.petOptions['dog-akita'].hungryState) {
+				if (!storedPets.petOptions?.[PetTypes.DOG_AKITA]?.hungryState) {
 					setToStorage('pets', {
 						...BASE_PET_OPTIONS,
 					})
@@ -124,7 +146,13 @@ export function PetProvider({ children }: { children: React.ReactNode }) {
 			}
 		}
 
-		load()
+		load().catch((err) => {
+			console.error('Failed to load pet settings', err)
+		})
+
+		return () => {
+			cancelled = true
+		}
 	}, [])
 
 	useEffect(() => {
@@ -163,89 +191,105 @@ export function PetProvider({ children }: { children: React.ReactNode }) {
 		}
 	}, [])
 
-	const getCurrentPetName = (petType: PetTypes) => {
-		const CurrentPet = settings.petOptions[petType]
-		if (CurrentPet) {
-			return CurrentPet.name
-		}
-		return ''
-	}
+	const getCurrentPetName = useCallback(
+		(petType: PetTypes) => settings.petOptions[petType]?.name ?? '',
+		[settings]
+	)
 
-	const levelUpHungryState = (petType: PetTypes) => {
+	const levelUpHungryState = useCallback((petType: PetTypes) => {
 		setSettings((prevSettings) => {
-			const newSettings = { ...prevSettings }
+			const pet = prevSettings.petOptions[petType]
+			if (!pet?.hungryState) return prevSettings
 
-			const pet = newSettings.petOptions[petType]
+			const gain = HUNGER_GAIN_STEPS[Math.floor(Math.random() * HUNGER_GAIN_STEPS.length)]
+			const nextLevel = Math.min(100, pet.hungryState.level + gain)
+			if (nextLevel === pet.hungryState.level) return prevSettings
 
-			if (pet && pet.hungryState?.level < 100) {
-				pet.hungryState.level += [10, 15, 25][Math.floor(Math.random() * 2)]
+			const newSettings: PetSettings = {
+				...prevSettings,
+				petOptions: {
+					...prevSettings.petOptions,
+					[petType]: {
+						...pet,
+						hungryState: { ...pet.hungryState, level: nextLevel },
+					},
+				},
 			}
 
-			if (pet.hungryState?.level > 100) {
-				pet.hungryState.level = 100
-			}
-
-			setToStorage('pets', newSettings)
-
+			pendingPersistRef.current = newSettings
 			return newSettings
 		})
-	}
+	}, [])
 
-	const levelDownHungryState = (petType: PetTypes) => {
+	const levelDownHungryState = useCallback((petType: PetTypes) => {
 		setSettings((prevSettings) => {
-			const newSettings = { ...prevSettings }
-			if (!newSettings.petType) {
-				return prevSettings
-			}
+			if (!prevSettings.petType) return prevSettings
 
-			const pet = newSettings.petOptions[petType]
+			const pet = prevSettings.petOptions[petType]
+			if (!pet?.hungryState) return prevSettings
 
 			const PER_SEC = 40 * 1000
 
-			if (pet?.hungryState?.lastHungerTick) {
+			if (pet.hungryState.lastHungerTick) {
 				const timeDiff = Date.now() - pet.hungryState.lastHungerTick
 				if (timeDiff < PER_SEC) {
 					return prevSettings
 				}
 			}
 
-			if (pet && pet.hungryState?.level > 0) {
-				const hungerDecrease = 1
-				pet.hungryState.level -= hungerDecrease
-				pet.hungryState.lastHungerTick = Date.now()
+			if (pet.hungryState.level <= 0) return prevSettings
+
+			const newSettings: PetSettings = {
+				...prevSettings,
+				petOptions: {
+					...prevSettings.petOptions,
+					[petType]: {
+						...pet,
+						hungryState: {
+							...pet.hungryState,
+							level: pet.hungryState.level - 1,
+							lastHungerTick: Date.now(),
+						},
+					},
+				},
 			}
 
-			setToStorage('pets', newSettings)
-
+			pendingPersistRef.current = newSettings
 			return newSettings
 		})
-	}
+	}, [])
 
-	const getPetHungryState = (petType: PetTypes) => {
-		const pet = settings.petOptions[petType]
-		if (pet) {
-			return pet.hungryState
-		}
-		return null
-	}
+	const getPetHungryState = useCallback(
+		(petType: PetTypes) => settings.petOptions[petType]?.hungryState ?? null,
+		[settings]
+	)
 
-	const isPetHungry = (petType: PetTypes): boolean => {
-		const pet = settings.petOptions[petType]
-		if (pet.hungryState?.level > 0) {
-			return false
-		}
+	const isPetHungry = useCallback(
+		(petType: PetTypes): boolean => {
+			const pet = settings.petOptions[petType]
+			return !(pet?.hungryState?.level && pet.hungryState.level > 0)
+		},
+		[settings]
+	)
 
-		return true
-	}
-
-	const contextValue: PetSettingsContextType = {
-		...settings,
-		getCurrentPetName,
-		levelUpHungryState,
-		isPetHungry,
-		levelDownHungryState,
-		getPetHungryState,
-	}
+	const contextValue = useMemo<PetSettingsContextType>(
+		() => ({
+			...settings,
+			getCurrentPetName,
+			levelUpHungryState,
+			isPetHungry,
+			levelDownHungryState,
+			getPetHungryState,
+		}),
+		[
+			settings,
+			getCurrentPetName,
+			levelUpHungryState,
+			isPetHungry,
+			levelDownHungryState,
+			getPetHungryState,
+		]
+	)
 
 	return <PetContext.Provider value={contextValue}>{children}</PetContext.Provider>
 }


### PR DESCRIPTION
## Problem

The akita dog would sometimes jump to the opposite corner of the widgetify card and float upward when it reached an edge.

## Root cause

Two pieces of code disagreed about which wall the pet was standing at.

`movePet` flips direction **away** from a wall on contact, so a pet resting against the right wall has `direction === -1`. `climbWall` then picked its wall from that direction rather than from the pet's actual `x`:

```ts
const wallX = currentDirection === 1 ? bounds.maxX : bounds.minX
```

So every climb that began right after a bounce moved the pet to the far wall in a single frame and then lifted it. It only happened *sometimes* because a climb starts only if the action timer expires inside the 5px band next to a wall — if the pet is still approaching, its direction is correct and nothing looks wrong.

**This affected every pet, not just the dog.** The dog is simply the fastest one:

| pet | walkSpeed | runSpeed |
|---|---|---|
| **dog** | **1.8** | **3.5** |
| cat | 1 | 1.8 |
| chicken | 1 | 2.5 |
| crab | 1 | 1.8 |
| frog | 1 | 1.8 |

At 3.5px per tick it crosses the 5px band in about one tick, so almost all of its time inside that band is post-bounce time. It is only noticeable in the widgetify card because there the sprite floats at `zIndex: 50` over the notification list, while the standalone pet widget gives it a dedicated empty strip.

## Fix

Movement maths moved into a pure `pet-movement` module so it can be tested without React:

- `pickClimbWall` resolves the **nearest wall from the pet's real position**
- the wall is latched when the climb starts, and the pet turns to face it
- bounds subtract the sprite **width** horizontally instead of its height, which was letting the pet overhang and clip at the right edge
- both container measurements now handle a zero value the same way

## Also fixed in the same area

- The physics loop no longer calls `setState` from inside a `setState` updater. Food collection ran there and **double counted hunger**.
- Food now falls from the top instead of rising out of the floor.
- Pending timeouts are cleared on unmount.
- Callbacks are held in refs so the loop stops capturing the first render's copies.
- Movement is scaled by frame delta, so speed no longer depends on the monitor refresh rate.
- Hunger updates copy the pet entry instead of mutating `BASE_PET_OPTIONS` in place, and persist outside the state updater.
- The `25` step in the hunger gain table was unreachable (`Math.random() * 2` over a three item array).
- The frog collectible re-rolled its colour every frame, through a Tailwind class that was never compiled so none of those colours existed in the bundle.
- The tooltip no longer renders mirrored (a CSS animation was overriding its inline `transform`), and flips below the pet when there is no room above.
- Drops the unused `hungryLevel` prop, dead enums, an empty `else` branch, adds a missing `alt`, and aligns the cat emoji between the two places that define it.

## Narrow windows

The pet container and its hunger hearts were gated behind `md:flex`, so below a 768px viewport both were `display: none` and the pet simply vanished. That breakpoint tracks the window, not the widget, so a perfectly usable widget could still lose its pet. Both now render at every width.

Showing the pet everywhere exposed a second problem: bounds were only applied while the pet was moving, so a pet that was idle or sitting when the container shrank stayed at its old `x`, outside the new bounds, and was clipped away by `overflow-hidden`. A `ResizeObserver` now clamps it back into view whenever the container changes size.

## Note

The food direction is unchanged from before this PR: it still rises from below the floor. Only its speed is now scaled by frame delta, along with the rest of the movement.

## Testing

`npm test` (53 tests), `npm run compile`, `biome check` and `npm run build` all pass. New suite covers the movement module, including a regression test asserting that a pet which just bounced off a wall climbs **that** wall rather than teleporting to the opposite one.

Worth a manual pass: leave the dog running in the widgetify card for a few minutes and confirm it never jumps between corners, that it is not clipped at the right edge, that food drops from above, and that eating one item raises the hearts by one step rather than two. Same checks in the standalone pet widget for regressions.


