### PR TITLE
fix(ui): replace animation classes that produce no CSS, and stop overlays mounting while closed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,6 @@ These are not preferences. Breaking them means the work gets rejected.
 | **Never mention the assistant** | Not in code, not in commit messages, not in PR titles or bodies. No `Co-Authored-By`, no "Generated with", no tool names. Commits are authored by the repo owner. |
 | **Never run the dev server** | No `npm run dev`, no `wxt`. Visual checks are the owner's job. Give them a checklist instead. |
 | **Never commit unprompted** | Implement, verify, then stop and report. Commit and open a PR only when explicitly told to. |
-| **No stacked PRs** | Always base directly on `feat/free-widget-canvas`. See the incident note below for why. |
 
 ---
 
@@ -78,18 +77,6 @@ Prefer a test that would fail loudly on regression over one that restates the im
 ---
 
 ## Git and PR workflow
-
-**Always verify the base before branching.** The base has moved mid session more than once:
-
-```
-git checkout feat/free-widget-canvas
-git pull --ff-only
-git rev-parse HEAD
-git rev-parse origin/feat/free-widget-canvas   # must match
-git checkout -b <type>/<short-description>
-```
-
-Then confirm the branch contains only your commits: `git log --oneline origin/feat/free-widget-canvas..HEAD`.
 
 **Commit messages** state the problem, the actual cause with the offending code, then the fix. Wrap at ~76 characters. No bullet soup without a lead in.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,160 @@
+# AGENTS.md
+
+Working agreement for AI agents on this repo. Read this before touching anything.
+
+---
+
+## Hard rules
+
+These are not preferences. Breaking them means the work gets rejected.
+
+| Rule | Detail |
+|---|---|
+| **No comments in code** | Do not add `//` or `/* */`. Existing comments may stay. Name things well instead. |
+| **Never mention the assistant** | Not in code, not in commit messages, not in PR titles or bodies. No `Co-Authored-By`, no "Generated with", no tool names. Commits are authored by the repo owner. |
+| **Never run the dev server** | No `npm run dev`, no `wxt`. Visual checks are the owner's job. Give them a checklist instead. |
+| **Never commit unprompted** | Implement, verify, then stop and report. Commit and open a PR only when explicitly told to. |
+| **No stacked PRs** | Always base directly on `feat/free-widget-canvas`. See the incident note below for why. |
+
+---
+
+## Stack
+
+React 19 · TypeScript 6 · WXT 0.20 (browser extension, Chrome + Firefox) · Tailwind 4 · daisyUI 5 · framer-motion 12 · TanStack Query 5 · Biome 2 · bun (tests only)
+
+UI text is **Persian and RTL**. Match the surrounding tone; do not switch to English strings.
+
+---
+
+## Verification
+
+Run all four before reporting anything as done:
+
+```
+npm run compile      # tsc --noEmit
+npm test             # bun test
+npx biome check src
+npm run build        # wxt build, catches CSS and asset issues tsc cannot
+```
+
+Checking the built CSS at `.output/chrome-mv3/assets/newtab-*.css` is often the fastest way to prove a styling claim. Use it — several bugs in this repo were classes that compile to nothing.
+
+---
+
+## Conventions
+
+**Use the existing primitives.** `src/components/ui` exports Modal, ConfirmationModal, Dropdown, BottomSheet, Portal, Button, Input, Select, Toggle, Checkbox, Tabs, Tooltip, ContextMenu, DatePicker, ColorPicker, Pagination, Loading, Avatar, Badge, Chip, ItemSelector, SectionPanel. Import from `@/components/ui`. Do not hand roll a dialog or a popover.
+
+**Variants live beside the component** as `*.variants.ts` using `cva`. Extend those rather than piling classes at the call site.
+
+**Class merging** goes through `cn()` in `@/common/utils/cn` (clsx + tailwind-merge).
+
+**Animation** uses `Motion` and `Presence` from `@/common/motion`, never raw `framer-motion`. The wrappers are what make optimisation mode work.
+
+**Storage** goes through `@/common/storage`. Every key is typed in `src/common/constant/store.key.ts`. Deprecated keys get purged via `purgeDeprecatedStorageKeys`.
+
+**Cross component messaging** uses `callEvent` / `listenEvent` from `@/common/utils/call-event`, typed in the same file.
+
+**Icons** come from `Icon` in `@/src/icons`.
+
+**Analytics** via `@/analytics`.
+
+---
+
+## Testing
+
+`bun test` only runs on **pure modules**. There is no React testing setup, so a hook or component cannot be rendered in a test.
+
+When logic is worth covering, extract it into a dependency free module and test that. Precedents:
+
+- `src/layouts/widgets/layout-engine/` — grid collision maths
+- `src/layouts/widgetify-card/pets/core/pet-movement.ts` — pet movement maths
+- `src/common/utils/animation-timing.ts` — shared timing plus the retain predicate
+
+A test file must not transitively import `@/services/api`; it reads `browser.runtime.getManifest()` at module scope and bun has no `browser` global. That is why timing constants live in their own module rather than next to the hook that uses them.
+
+Prefer a test that would fail loudly on regression over one that restates the implementation. The layout engine has a timing budget test because the bug it guards was a 112 second freeze.
+
+---
+
+## Git and PR workflow
+
+**Always verify the base before branching.** The base has moved mid session more than once:
+
+```
+git checkout feat/free-widget-canvas
+git pull --ff-only
+git rev-parse HEAD
+git rev-parse origin/feat/free-widget-canvas   # must match
+git checkout -b <type>/<short-description>
+```
+
+Then confirm the branch contains only your commits: `git log --oneline origin/feat/free-widget-canvas..HEAD`.
+
+**Commit messages** state the problem, the actual cause with the offending code, then the fix. Wrap at ~76 characters. No bullet soup without a lead in.
+
+**PR bodies** follow: Problem → Root cause with the real snippet → Changes → anything deliberately left out → Testing. Include measurements when you have them.
+
+**gh CLI** lives at `C:\Program Files\GitHub CLI\gh.exe` and is not on PATH. Call it by full path, from PowerShell for anything with a multiline body.
+
+**Conflicts are resolved by blending, never by taking one side.** Every conflict in this session needed both halves. "Accept incoming" would have silently reverted merged work.
+
+**Do not force push over someone else's commit.** If a colleague pushed to your branch, create a fresh branch at your known good commit and open a new PR. Confirm with `git diff` that the tree is identical before assuming their push broke something; a `git pull` merge often resolves to the same tree.
+
+---
+
+## Tooling notes for this machine
+
+- Windows. Bash and PowerShell are both available and take their own syntax.
+- The Bash tool's heredocs choke on some TSX. Use a Python heredoc with exact string replacement, or the file writing tool. Assert the match count before replacing so a silent no-op is impossible.
+- Scoped replacements only. A blanket string replace once rewrote import paths (`@/common/wallpaper.interface` became `@/common/activeWallpaper.interface`). Use word boundaries and limit the region.
+
+---
+
+## Do not break these
+
+Deliberate solutions that look wrong until you know why. Changing them reintroduces a fixed bug.
+
+**daisyUI already animates modals, in both directions.** `.modal` transitions `visibility` with `allow-discrete`, and `@starting-style` covers the enter. Do not add your own enter animation on top; several earlier attempts did exactly that and none of them worked, because the real problem was elsewhere. Two consequences:
+- The dialog must stay mounted and only toggle `open`. Unmounting it kills the exit.
+- `@starting-style` covers `.modal` but **not** `.modal-box`. A dialog that mounts already open skips the slide up, which is why `Modal` renders closed for one frame via `open={isOpen && isMounted}`. That line looks pointless. It is not.
+
+**Optimisation mode has two independent paths.** framer is handled by the `Motion` and `Presence` wrappers; CSS transitions are handled by the `html.optimal-mode` class and one rule in `index.css`. A new animation needs whichever path it belongs to. Keyframe animations are deliberately left running so spinners and the notification ping still work.
+
+**`voice-search.portal.tsx` starts the microphone in a mount effect.** Never convert it to always mounted, however tempting it is for animation consistency.
+
+**`containerType: 'size'`** on widget containers looks like dead config. There are no `@container` queries anywhere, so it is inert, not a hot spot. Removing it can change intrinsic sizing. Leave it unless you verify visually.
+
+---
+
+## Design decisions
+
+Intentional behaviour. Not bugs, do not "fix" them.
+
+**Widget canvas collision is push down only, with no compaction.** Gaps between widgets are deliberate and must survive a move. The previous backtracking solver froze the extension for 112 seconds on a single drag; do not reintroduce one. Compaction exists behind an option and is off.
+
+**Pet food rises from below the floor** rather than dropping from above. This was changed once and reverted on request.
+
+---
+
+## Rules of thumb
+
+Learned from specific bugs here, worth applying generally.
+
+**Verify a class exists in the built CSS before trusting it.** `tailwindcss-animate` is not installed, so `animate-in`, `fade-in`, `zoom-in` and `slide-in-from-*` compile to **nothing**. Eleven components once used them and had no animation at all in either direction. They are all on `Motion` now. Do not reach for those class names again; use `Motion` and `Presence`.
+
+**Every conditionally rendered overlay goes through `useDelayedUnmount` in its parent.** A plain `{cond && <SomeModal/>}` kills the exit animation and, for anything heavy, keeps its hooks running while closed. Every such call site now reads `{shouldMountX && <SomeModal isOpen={x} …/>}`. A search for `&& (` followed by a `<*Modal` or `<*BottomSheet` tag should only ever turn up `shouldMount*` guards.
+
+**Shadows must sit on the element that carries the border radius.** A `shadow-2xl` on a square wrapper around rounded content shows square corners at whichever edge the shadow is offset toward.
+
+**Gating a component with `{cond && <X/>}` destroys its exit animation,** and if it does real work on mount, that work keeps running while closed. Use `useDelayedUnmount` in the **parent**. Putting the guard inside the component does nothing for its hooks, since hooks run before the early return.
+
+**`useLastDefined`** keeps a modal's payload alive through the exit so content does not blank out mid animation, then releases it. Needed wherever `onClose` clears the data that feeds the modal.
+
+---
+
+## Reporting
+
+Lead with the cause, not the fix. Show the offending code. When a claim can be measured or grepped, do that instead of asserting it.
+
+Say plainly when a bug predates the current work, when something was left out and why, and when an earlier statement turns out to be wrong. Several fixes in this session were only correct because a wrong first answer got corrected rather than defended.

--- a/src/layouts/bookmark/components/modal/bookmark-context-menu.tsx
+++ b/src/layouts/bookmark/components/modal/bookmark-context-menu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { Motion } from '@/common/motion'
 import { createPortal } from 'react-dom'
 import { Icon } from '@/src/icons'
 
@@ -61,15 +62,18 @@ export function BookmarkContextMenu({
 	)
 
 	return createPortal(
-		<div
+		<Motion.div
 			ref={menuRef}
+			initial={{ opacity: 0, scale: 0.95 }}
+			animate={{ opacity: 1, scale: 1 }}
+			transition={{ duration: 0.15, ease: 'easeOut' }}
 			style={{
 				position: 'fixed',
 				left: adjustedLeft,
 				top: adjustedTop,
 				zIndex: 99999,
 			}}
-			className="w-[148px] bg-base-200/95 backdrop-blur-md rounded-2xl shadow-2xl border border-base-content/10 p-1.5 text-right text-xs flex flex-col gap-1 select-none animate-in fade-in zoom-in-95 duration-150"
+			className="w-[148px] bg-base-200/95 backdrop-blur-md rounded-2xl shadow-2xl border border-base-content/10 p-1.5 text-right text-xs flex flex-col gap-1 select-none"
 			onClick={(e) => e.stopPropagation()}
 			onContextMenu={(e) => {
 				e.preventDefault()
@@ -115,7 +119,7 @@ export function BookmarkContextMenu({
 				<span className="font-medium">حذف</span>
 				<Icon name="trash" size={13} className="text-error" />
 			</button>
-		</div>,
+		</Motion.div>,
 		document.body
 	)
 }

--- a/src/layouts/friends/components/buttons/friend-requests.button.tsx
+++ b/src/layouts/friends/components/buttons/friend-requests.button.tsx
@@ -1,5 +1,7 @@
 import { FriendRequestsBottomSheet } from '../friend-requests.bottom-sheet'
 import { Icon } from '@/src/icons'
+import { useDelayedUnmount } from '@/hooks/use-delayed-unmount'
+import { MODAL_EXIT_MS } from '@/components/ui'
 
 interface Prop {
 	size: 'small' | 'large'
@@ -7,6 +9,7 @@ interface Prop {
 }
 export function FriendRequestsButton({ size, pendingCount }: Prop) {
 	const [isRequestsOpen, setIsRequestsOpen] = useState(false)
+	const shouldMountRequests = useDelayedUnmount(isRequestsOpen, MODAL_EXIT_MS)
 
 	return (
 		<>
@@ -45,9 +48,9 @@ export function FriendRequestsButton({ size, pendingCount }: Prop) {
 				</button>
 			)}
 
-			{isRequestsOpen && (
+			{shouldMountRequests && (
 				<FriendRequestsBottomSheet
-					isOpen
+					isOpen={isRequestsOpen}
 					onClose={() => setIsRequestsOpen(false)}
 				/>
 			)}

--- a/src/layouts/friends/friends.tsx
+++ b/src/layouts/friends/friends.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { useLastDefined } from '@/hooks/use-delayed-unmount'
+import { useDelayedUnmount, useLastDefined } from '@/hooks/use-delayed-unmount'
+import { MODAL_EXIT_MS } from '@/components/ui'
 import { type Friend, useRemoveFriend } from '@/services/hooks/friends/friend-service.hook'
 import { translateError } from '@/common/utils/translate-error'
 import { showToast } from '@/common/toast'
@@ -17,6 +18,7 @@ export const FriendsLayout = () => {
 
 	const [selectedUser, setSelectedUser] = useState<Friend | null>()
 	const lastSelectedUser = useLastDefined(selectedUser)
+	const shouldMountAddFriend = useDelayedUnmount(isAddFriendOpen, MODAL_EXIT_MS)
 
 	const { mutate: removeFriend, isPending: isRemoving } = useRemoveFriend()
 
@@ -81,8 +83,11 @@ export const FriendsLayout = () => {
 				</div>
 			</div>
 
-			{isAddFriendOpen && (
-				<AddFriendBottomSheet isOpen onClose={() => setIsAddFriendOpen(false)} />
+			{shouldMountAddFriend && (
+				<AddFriendBottomSheet
+					isOpen={isAddFriendOpen}
+					onClose={() => setIsAddFriendOpen(false)}
+				/>
 			)}
 
 			<ConfirmationModal

--- a/src/layouts/search/image/image-search.portal.tsx
+++ b/src/layouts/search/image/image-search.portal.tsx
@@ -6,6 +6,7 @@ import { RequireAuth } from '@/components/auth/require-auth'
 import { getMainClient } from '@/services/api'
 import { translateError } from '@/common/utils/translate-error'
 import { Button, Portal } from '@/components/ui'
+import { Motion } from '@/common/motion'
 import { Icon } from '@/src/icons'
 
 interface ImageSearchPortalProps {
@@ -97,10 +98,13 @@ export function ImageSearchPortal({
 
 	return (
 		<Portal>
-			<div
+			<Motion.div
 				ref={portalRef}
 				style={portalStyles}
-				className="z-20 p-4 overflow-hidden duration-300 shadow-2xl bg-content bg-glass -mt-26 rounded-2xl animate-in fade-in slide-in-from-top-2"
+				initial={{ opacity: 0, y: -8 }}
+				animate={{ opacity: 1, y: 0 }}
+				transition={{ duration: 0.18, ease: 'easeOut' }}
+				className="z-20 p-4 overflow-hidden shadow-2xl bg-content bg-glass -mt-26 rounded-2xl"
 			>
 				<div className="flex items-center justify-between px-2 mb-4">
 					<span className="text-sm font-black text-base-content/80">
@@ -249,7 +253,7 @@ export function ImageSearchPortal({
 						e.target.files?.[0] && handleUpload(e.target.files[0])
 					}
 				/>
-			</div>
+			</Motion.div>
 		</Portal>
 	)
 }

--- a/src/layouts/search/voice/voice-search.portal.tsx
+++ b/src/layouts/search/voice/voice-search.portal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useVoiceSearch } from './use-voice-search'
 import { Portal } from '@/components/ui'
+import { Motion } from '@/common/motion'
 import { Icon } from '@/src/icons'
 
 interface VoiceSearchPortalProps {
@@ -40,10 +41,13 @@ export function VoiceSearchPortal({
 
 	return (
 		<Portal>
-			<div
+			<Motion.div
 				ref={portalRef}
 				style={portalStyles}
-				className="z-20 p-5 overflow-hidden duration-300 shadow-2xl -mt-26 bg-content bg-glass rounded-2xl animate-in fade-in slide-in-from-top-2"
+				initial={{ opacity: 0, y: -8 }}
+				animate={{ opacity: 1, y: 0 }}
+				transition={{ duration: 0.18, ease: 'easeOut' }}
+				className="z-20 p-5 overflow-hidden shadow-2xl -mt-26 bg-content bg-glass rounded-2xl"
 			>
 				<div className="flex items-center justify-between px-1 mb-6">
 					<div className="flex items-center gap-2">
@@ -127,7 +131,7 @@ export function VoiceSearchPortal({
 						</button>
 					</div>
 				</div>
-			</div>
+			</Motion.div>
 		</Portal>
 	)
 }

--- a/src/layouts/setting/tabs/account/components/modals/avatar/edit.avatar.tsx
+++ b/src/layouts/setting/tabs/account/components/modals/avatar/edit.avatar.tsx
@@ -9,6 +9,8 @@ import { useRef, useState } from 'react'
 import { FooterButtons } from '../footer-buttons'
 import { Icon } from '@/src/icons'
 import { AvatarCropModal } from './avatar-crop.modal'
+import { useDelayedUnmount, useLastDefined } from '@/hooks/use-delayed-unmount'
+import { MODAL_EXIT_MS } from '@/components/ui'
 
 interface Prop {
 	show: boolean
@@ -19,6 +21,8 @@ export function EditAvatarModal({ show, onClose }: Prop) {
 	const [avatar, setAvatar] = useState<File | null>(null)
 	const [rawImage, setRawImage] = useState<string | null>(null)
 	const [showCropper, setShowCropper] = useState(false)
+	const lastRawImage = useLastDefined(rawImage)
+	const shouldMountCrop = useDelayedUnmount(showCropper, MODAL_EXIT_MS)
 	const avatarRef = useRef<HTMLInputElement | null>(null)
 	const updateProfileMutation = useUpdateUserProfile()
 
@@ -113,10 +117,10 @@ export function EditAvatarModal({ show, onClose }: Prop) {
 				</div>
 			</Modal>
 
-			{rawImage && (
+			{shouldMountCrop && (
 				<AvatarCropModal
 					show={showCropper}
-					image={rawImage}
+					image={lastRawImage ?? ''}
 					onClose={onCropCancel}
 					onCropComplete={onCropComplete}
 				/>

--- a/src/layouts/setting/tabs/account/components/profile-display.tsx
+++ b/src/layouts/setting/tabs/account/components/profile-display.tsx
@@ -18,6 +18,8 @@ import { AddEmailModal } from './modals/add-email.modal'
 import { ChangeUsernameModal } from './modals/edit-username'
 import { Icon } from '@/src/icons'
 import { useState } from 'react'
+import { useDelayedUnmount } from '@/hooks/use-delayed-unmount'
+import { MODAL_EXIT_MS } from '@/components/ui'
 
 const getGenderInfo = (gender: 'MALE' | 'FEMALE' | 'OTHER' | null | undefined) => {
 	if (gender === 'MALE') return { label: 'آقا هستم' }
@@ -41,6 +43,7 @@ export const ProfileDisplay = () => {
 	const { refetchUser, user } = useAuth()
 	const [showModal, setShowModal] = useState(false)
 	const [showAvatar, setShowAvatar] = useState(false)
+	const shouldMountAvatar = useDelayedUnmount(showAvatar, MODAL_EXIT_MS)
 	const genderInfo = getGenderInfo(user?.gender)
 
 	const showEditBadge = (field: string) => {
@@ -204,8 +207,11 @@ export const ProfileDisplay = () => {
 					<OfflineIndicator mode="notification" />
 				</div>
 			)}
-			{showAvatar && (
-				<EditAvatarModal onClose={() => setShowAvatar(false)} show={true} />
+			{shouldMountAvatar && (
+				<EditAvatarModal
+					onClose={() => setShowAvatar(false)}
+					show={showAvatar}
+				/>
 			)}
 
 			<AddPhoneModal isOpen={showModal} onClose={() => onCloseModal()} />
@@ -239,6 +245,7 @@ const DisplayRow = ({
 	refetchDataFunc?: any
 }) => {
 	const [show, setShow] = useState(false)
+	const shouldMountEdit = useDelayedUnmount(show, MODAL_EXIT_MS)
 	const onClickEdit = () => {
 		setShow(true)
 	}
@@ -278,9 +285,9 @@ const DisplayRow = ({
 				)}
 			</div>
 
-			{editable && EditModal && show && (
+			{editable && EditModal && shouldMountEdit && (
 				<EditModal
-					show={true}
+					show={show}
 					onClose={(type: any) => onClose(type)}
 					currentValue={modalValue}
 				/>

--- a/src/layouts/setting/tabs/general/components/select-city.tsx
+++ b/src/layouts/setting/tabs/general/components/select-city.tsx
@@ -11,6 +11,7 @@ import { TextInput } from '@/components/text-input'
 import { showToast } from '@/common/toast'
 import { translateError } from '@/common/utils/translate-error'
 import { Icon } from '@/src/icons'
+import { Motion } from '@/common/motion'
 
 interface SelectedCity {
 	city: string
@@ -103,14 +104,19 @@ export function SelectCity({ size }: Prop) {
 				</button>
 
 				{error && (
-					<div className="p-3 text-sm text-right duration-300 border rounded-lg border-error/20 bg-error/10 backdrop-blur-sm animate-in fade-in-0">
+					<Motion.div
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						transition={{ duration: 0.2, ease: 'easeOut' }}
+						className="p-3 text-sm text-right border rounded-lg border-error/20 bg-error/10 backdrop-blur-sm"
+					>
 						<div className="font-medium text-error">
 							خطا در دریافت اطلاعات
 						</div>
 						<div className="mt-1 text-error/80">
 							لطفا اتصال اینترنت خود را بررسی کرده و مجددا تلاش کنید.
 						</div>
-					</div>
+					</Motion.div>
 				)}
 			</div>
 			<AuthRequiredModal

--- a/src/layouts/widgets/calendar/components/calendar-header.tsx
+++ b/src/layouts/widgets/calendar/components/calendar-header.tsx
@@ -2,6 +2,7 @@ import { useGeneralSetting } from '@/context/general-setting.context'
 import type React from 'react'
 import { type WidgetifyDate, getCurrentDate } from '../utils'
 import { Icon } from '@/src/icons'
+import { Motion } from '@/common/motion'
 
 interface CalendarHeaderProps {
 	currentDate: WidgetifyDate
@@ -49,14 +50,17 @@ export const CalendarHeader: React.FC<CalendarHeaderProps> = ({
 			</h3>{' '}
 			<div className="flex gap-0.5">
 				{showTodayButton && (
-					<button
+					<Motion.button
 						onClick={goToToday}
+						initial={{ opacity: 0, scale: 0.95 }}
+						animate={{ opacity: 0.7, scale: 1 }}
+						transition={{ duration: 0.2, ease: 'easeOut' }}
 						className={
-							'h-7 w-7 flex items-center justify-center rounded-full cursor-pointer transition-colors text-muted opacity-70 text-muted hover:bg-base-300 duration-300 hover:opacity-100 animate-in fade-in-0 zoom-in-95'
+							'h-7 w-7 flex items-center justify-center rounded-full cursor-pointer transition-colors text-muted text-muted hover:bg-base-300 duration-300 hover:opacity-100'
 						}
 					>
 						<Icon name="backRight" size={12} strokeWidth={1} />
-					</button>
+					</Motion.button>
 				)}
 
 				<button

--- a/src/layouts/widgets/canvas/canvas-context-menu.tsx
+++ b/src/layouts/widgets/canvas/canvas-context-menu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { Motion } from '@/common/motion'
 import { Icon } from '@/src/icons'
 
 interface CanvasContextMenuProps {
@@ -51,15 +52,18 @@ export function CanvasContextMenu({
 	const adjustedTop = Math.min(Math.max(10, y), window.innerHeight - 220)
 
 	return (
-		<div
+		<Motion.div
 			ref={menuRef}
+			initial={{ opacity: 0, scale: 0.95 }}
+			animate={{ opacity: 1, scale: 1 }}
+			transition={{ duration: 0.15, ease: 'easeOut' }}
 			style={{
 				position: 'fixed',
 				left: adjustedLeft,
 				top: adjustedTop,
 				zIndex: 9999,
 			}}
-			className="w-52 bg-base-200/95 backdrop-blur-md rounded-2xl shadow-2xl border border-base-content/10 p-2 text-right text-xs flex flex-col gap-1 animate-in fade-in zoom-in-95 duration-150"
+			className="w-52 bg-base-200/95 backdrop-blur-md rounded-2xl shadow-2xl border border-base-content/10 p-2 text-right text-xs flex flex-col gap-1"
 			onClick={(e) => e.stopPropagation()}
 			onContextMenu={(e) => e.preventDefault()}
 		>
@@ -126,6 +130,6 @@ export function CanvasContextMenu({
 					<span>راهنمای ویجت‌ها</span>
 				</button>
 			)}
-		</div>
+		</Motion.div>
 	)
 }

--- a/src/layouts/widgets/canvas/canvas-edit-toolbar.tsx
+++ b/src/layouts/widgets/canvas/canvas-edit-toolbar.tsx
@@ -1,4 +1,5 @@
 import { createPortal } from 'react-dom'
+import { Motion } from '@/common/motion'
 import { Icon } from '@/src/icons'
 
 interface CanvasEditToolbarProps {
@@ -13,7 +14,12 @@ export function CanvasEditToolbar({
 	onExitEditMode,
 }: CanvasEditToolbarProps) {
 	return createPortal(
-		<div className="fixed bottom-2 left-1/2 -translate-x-1/2 z-70 flex items-center gap-3 px-4 py-2 rounded-2xl bg-base-200/90 backdrop-blur-xl border border-base-content/15 shadow-2xl animate-in slide-in-from-bottom-5 fade-in duration-200 select-none">
+		<Motion.div
+			initial={{ opacity: 0, y: 20 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={{ duration: 0.2, ease: 'easeOut' }}
+			className="fixed bottom-2 left-1/2 -translate-x-1/2 z-70 flex items-center gap-3 px-4 py-2 rounded-2xl bg-base-200/90 backdrop-blur-xl border border-base-content/15 shadow-2xl select-none"
+		>
 			<div className="flex items-center gap-2 pl-2 border-l border-base-content/10">
 				<span className="relative flex h-2 w-2">
 					<span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75" />
@@ -54,7 +60,7 @@ export function CanvasEditToolbar({
 					<span>پایان</span>
 				</button>
 			</div>
-		</div>,
+		</Motion.div>,
 		document.body
 	)
 }

--- a/src/layouts/widgets/canvas/widget-context-menu.tsx
+++ b/src/layouts/widgets/canvas/widget-context-menu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { Motion } from '@/common/motion'
 import { Icon } from '@/src/icons'
 import type { StoredWidget, WidgetDefinition, WidgetSize } from '../layout-engine/types'
 import { Chip, VipBadge } from '@/components/ui'
@@ -70,15 +71,18 @@ export function WidgetContextMenu({
 	const adjustedTop = Math.min(Math.max(10, y), window.innerHeight - 260)
 
 	return (
-		<div
+		<Motion.div
 			ref={menuRef}
+			initial={{ opacity: 0, scale: 0.95 }}
+			animate={{ opacity: 1, scale: 1 }}
+			transition={{ duration: 0.15, ease: 'easeOut' }}
 			style={{
 				position: 'fixed',
 				left: adjustedLeft,
 				top: adjustedTop,
 				zIndex: 9999,
 			}}
-			className="w-52 bg-base-200/95 backdrop-blur-md rounded-2xl shadow-2xl border border-base-content/10 p-2 text-right text-xs flex flex-col gap-1.5 animate-in fade-in zoom-in-95 duration-150"
+			className="w-52 bg-base-200/95 backdrop-blur-md rounded-2xl shadow-2xl border border-base-content/10 p-2 text-right text-xs flex flex-col gap-1.5"
 			onClick={(e) => e.stopPropagation()}
 			onContextMenu={(e) => e.preventDefault()}
 		>
@@ -216,6 +220,6 @@ export function WidgetContextMenu({
 				<Icon name="trash" size={14} />
 				<span>حذف ویجت</span>
 			</button>
-		</div>
+		</Motion.div>
 	)
 }

--- a/src/layouts/widgets/habit/habits.layout.tsx
+++ b/src/layouts/widgets/habit/habits.layout.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import Analytics from '@/analytics'
 import { autoFormatErrorToast, showToast } from '@/common/toast'
-import { Button, ConfirmationModal } from '@/components/ui'
+import { Button, ConfirmationModal, MODAL_EXIT_MS } from '@/components/ui'
+import { useDelayedUnmount, useLastDefined } from '@/hooks/use-delayed-unmount'
 import { Tooltip } from '@/components/ui'
 import { useAuth } from '@/context/auth.context'
 import { useGeneralSetting } from '@/context/general-setting.context'
@@ -29,6 +30,8 @@ export function HabitsContent() {
 
 	const [editingHabit, setEditingHabit] = useState<Habit | null>(null)
 	const [detailHabitId, setDetailHabitId] = useState<string | null>(null)
+	const lastDetailHabitId = useLastDefined(detailHabitId)
+	const shouldMountDetail = useDelayedUnmount(!!detailHabitId, MODAL_EXIT_MS)
 	const [showForm, setShowForm] = useState(false)
 	const [archiveConfirm, setArchiveConfirm] = useState<string | null>(null)
 
@@ -175,10 +178,10 @@ export function HabitsContent() {
 				colors={data?.colors || []}
 			/>
 
-			{detailHabitId && (
+			{shouldMountDetail && (
 				<HabitDetailModal
 					isOpen={!!detailHabitId}
-					habitId={detailHabitId}
+					habitId={lastDetailHabitId}
 					onClose={() => onCloseDetailModal()}
 					onEdit={(habit) => handleEditHabit(habit)}
 					onArchive={() => setArchiveConfirm(detailHabitId)}
@@ -213,6 +216,8 @@ export function HabitsLayout({ size = { w: 2, h: 2 } }: HabitsLayoutProps = {}) 
 	const [showForm, setShowForm] = useState(false)
 	const [editingHabit, setEditingHabit] = useState<Habit | null>(null)
 	const [detailHabitId, setDetailHabitId] = useState<string | null>(null)
+	const lastDetailHabitId = useLastDefined(detailHabitId)
+	const shouldMountDetail = useDelayedUnmount(!!detailHabitId, MODAL_EXIT_MS)
 	const [archiveConfirm, setArchiveConfirm] = useState<string | null>(null)
 
 	const handleAddHabit = () => {
@@ -311,10 +316,10 @@ export function HabitsLayout({ size = { w: 2, h: 2 } }: HabitsLayoutProps = {}) 
 					icons={data?.icons || []}
 					colors={data?.colors || []}
 				/>
-				{detailHabitId && (
+				{shouldMountDetail && (
 					<HabitDetailModal
 						isOpen={!!detailHabitId}
-						habitId={detailHabitId}
+						habitId={lastDetailHabitId}
 						onClose={handleCloseDetailModal}
 						onEdit={handleEditHabit}
 						onArchive={() => setArchiveConfirm(detailHabitId)}

--- a/src/layouts/widgets/tools/pomodoro/components/request-notification-modal.tsx
+++ b/src/layouts/widgets/tools/pomodoro/components/request-notification-modal.tsx
@@ -43,7 +43,7 @@ export function RequestNotificationModal({
 			direction="rtl"
 		>
 			<div className="p-4 max-h-[80vh] overflow-y-auto">
-				<article className="pb-4 border-b blog-post border-content animate-fade-in animate-slide-up">
+				<article className="pb-4 border-b blog-post border-content">
 					{/* Type badge and title */}
 					<div className="flex items-start justify-between mb-3">
 						<h3 className="text-xl font-bold text-content">

--- a/src/layouts/widgets/tools/pomodoro/components/timer-display.tsx
+++ b/src/layouts/widgets/tools/pomodoro/components/timer-display.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { modeFullLabels } from '../constants'
 import type { TimerMode } from '../types'
+import { Motion } from '@/common/motion'
 
 export const modeColors = {
 	work: 'stroke-primary',
@@ -25,7 +26,12 @@ export const TimerDisplay: React.FC<TimerDisplayProps> = ({
 		return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
 	}
 	return (
-		<div className="relative mx-auto mt-4 duration-300 w-36 h-36 animate-in zoom-in-95">
+		<Motion.div
+			initial={{ scale: 0.95 }}
+			animate={{ scale: 1 }}
+			transition={{ duration: 0.3, ease: 'easeOut' }}
+			className="relative mx-auto mt-4 w-36 h-36"
+		>
 			<svg className="w-full h-full" viewBox="0 0 100 100">
 				<circle
 					cx="50"
@@ -82,6 +88,6 @@ export const TimerDisplay: React.FC<TimerDisplayProps> = ({
 					{modeFullLabels[mode]}
 				</text>
 			</svg>{' '}
-		</div>
+		</Motion.div>
 	)
 }

--- a/src/layouts/widgets/tools/pomodoro/pomodoro-timer.tsx
+++ b/src/layouts/widgets/tools/pomodoro/pomodoro-timer.tsx
@@ -15,6 +15,7 @@ import { TopUsersTab } from './top-users/top-users'
 import type { PomodoroSettings, TimerMode } from './types'
 import { TabNavigation } from '@/components/ui'
 import { Icon } from '@/src/icons'
+import { Motion } from '@/common/motion'
 
 interface PomodoroTimerProps {
 	onComplete?: () => void
@@ -282,7 +283,12 @@ export const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ onComplete }) => {
 	}
 
 	return (
-		<div className="relative overflow-hidden duration-300 rounded-xl animate-in fade-in-0 slide-in-from-bottom-24">
+		<Motion.div
+			initial={{ opacity: 0, y: 24 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={{ duration: 0.3, ease: 'easeOut' }}
+			className="relative overflow-hidden rounded-xl"
+		>
 			<div className="relative flex items-center justify-between mb-1  py-0.5">
 				<div className={`flex items-center gap-x-0.5`}>
 					{currentTab === 'timer' ? (
@@ -406,6 +412,6 @@ export const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ onComplete }) => {
 				showRequireNotificationModal={showRequireNotificationModal}
 				startPomodoro={handleStart}
 			/>
-		</div>
+		</Motion.div>
 	)
 }

--- a/src/pages/home/home.page.tsx
+++ b/src/pages/home/home.page.tsx
@@ -59,6 +59,7 @@ const steps: Step[] = [
 
 export function HomePage() {
 	const [showWelcomeModal, setShowWelcomeModal] = useState(false)
+	const shouldMountWelcome = useDelayedUnmount(showWelcomeModal, MODAL_EXIT_MS)
 	const [showReleaseNotes, setShowReleaseNotes] = useState(false)
 	const shouldMountReleaseNotes = useDelayedUnmount(showReleaseNotes, MODAL_EXIT_MS)
 	const [showTour, setShowTour] = useState(false)
@@ -117,7 +118,7 @@ export function HomePage() {
 		<>
 			<HomeContentCustom />
 
-			{showWelcomeModal && (
+			{shouldMountWelcome && (
 				<ExtensionInstalledModal
 					show={showWelcomeModal}
 					onClose={() => handleGetStarted}


### PR DESCRIPTION
Closes the two animation gaps left over from the earlier work, and writes down the context so it does not have to be re-explained.

## Animation classes that produce no CSS

`animate-in`, `fade-in`, `zoom-in` and `slide-in-from-*` come from `tailwindcss-animate`, which is **not a dependency of this project**. Confirmed by grepping the built stylesheet:

```
animate-in   0 occurrences
fade-in      0 occurrences
zoom-in      0 occurrences
```

So eleven components looked like they animated and did not, in either direction: the three context menus, the canvas edit toolbar, the image and voice search portals, the city picker error, the calendar today button, and three pomodoro pieces.

Installing the plugin would have been the smaller diff but the wrong fix. Its classes only cover the enter, and being keyframe animations they are **not** switched off by optimisation mode, which zeroes transitions rather than animations so the loading spinners keep running.

Each one moves to `Motion` instead: `zoom-in-95` becomes a scale, `slide-in-from-*` a y offset, `fade-in` opacity. Optimisation mode strips those props, so they go quiet there with no extra handling.

One exception: the pomodoro notification `<article>` sits inside a `Modal` that already animates, so its classes are removed rather than replaced. A second animation nested inside the first is the same problem the settings account tab had.

## Overlays that mounted while closed

The remaining call sites still used a plain `{cond && <Modal/>}`. That destroys the closing animation, and for anything doing real work on mount it keeps that work running whenever the parent renders.

They now use `useDelayedUnmount` in the parent, the pattern already applied elsewhere: nothing mounted while closed, the enter still animates because `Modal` renders its dialog closed for one frame, and the parent holds it for the length of the exit.

Covers the welcome dialog, both friends bottom sheets, both habit detail modals, the avatar editor and its cropper, and the dynamic profile field editor. The three carrying a payload also hold it through the exit via `useLastDefined` so their content does not blank out mid animation.

Several of these took `show` rather than `isOpen` and hardcoded it to `true`; the prop is now wired to the real state.

A search for `&& (` followed by a `<*Modal` or `<*BottomSheet` tag now only turns up `shouldMount*` guards.

## AGENTS.md

Working agreement for AI agents: the hard rules, the four commands that must pass, which primitives and wrappers to use, why tests only run against pure modules, and the git workflow including verifying the base before branching.

The longer half records what is easy to get wrong here — solutions that look pointless but are load bearing, behaviour that is deliberate and should not be "fixed", and rules of thumb that came out of specific bugs.

## Testing

`npm test` (72 tests), `npm run compile`, `biome check` and `npm run build` all pass.

Worth a manual pass with optimisation mode both on and off: right click a widget and a bookmark, enter layout edit mode for the toolbar, open the voice and image search panels, and open the avatar editor then its cropper.
