### PR TITLE
fix: stop bookmark modal scrollbar flash on button press

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ These are not preferences. Breaking them means the work gets rejected.
 | **Never mention the assistant** | Not in code, not in commit messages, not in PR titles or bodies. No `Co-Authored-By`, no "Generated with", no tool names. Commits are authored by the repo owner. |
 | **Never run the dev server** | No `npm run dev`, no `wxt`. Visual checks are the owner's job. Give them a checklist instead. |
 | **Never commit unprompted** | Implement, verify, then stop and report. Commit and open a PR only when explicitly told to. |
+| **New branch per fix/feature** | Before editing, create a new branch off the current one (whatever it is) named for the task. Make the changes there, uncommitted. Stop after verification and let the owner test visually themselves. Only commit and open a PR when explicitly told to, in that order. |
 
 ---
 

--- a/src/layouts/bookmark/components/modal/add-bookmark.modal.tsx
+++ b/src/layouts/bookmark/components/modal/add-bookmark.modal.tsx
@@ -256,7 +256,7 @@ export function AddBookmarkModal({
 								type="button"
 								onClick={onCloseHandler}
 								size="md"
-								className="w-20 transition-colors duration-300 ease-in-out border-none shadow-none btn bg-base-300 hover:bg-error/10 text-base-content/80 hover:text-error rounded-2xl"
+								className="w-20 transition-colors duration-300 ease-in-out border-none shadow-none bg-base-300 hover:bg-error/10 text-base-content/80 hover:text-error rounded-2xl"
 							>
 								لغو
 							</Button>
@@ -269,7 +269,7 @@ export function AddBookmarkModal({
 								}
 								size="md"
 								loading={isAdding}
-								className="transition-colors duration-300 ease-in-out border-none shadow-none btn w-28 rounded-2xl"
+								className="transition-colors duration-300 ease-in-out border-none shadow-none w-28 rounded-2xl"
 								variant="primary"
 							>
 								ذخیره

--- a/src/layouts/bookmark/components/modal/advanced.modal.tsx
+++ b/src/layouts/bookmark/components/modal/advanced.modal.tsx
@@ -328,7 +328,7 @@ export function AdvancedModal({ title, onClose, isOpen, bookmark }: AdvancedModa
 						size="md"
 						onClick={() => onClose(null)}
 						rounded={'2xl'}
-						className="w-20 transition-colors duration-300 ease-in-out border-none shadow-none btn bg-base-300 hover:bg-error/10 text-base-content/80 hover:text-error rounded-2xl"
+						className="w-20 transition-colors duration-300 ease-in-out border-none shadow-none bg-base-300 hover:bg-error/10 text-base-content/80 hover:text-error rounded-2xl"
 					>
 						لغو
 					</Button>

--- a/src/layouts/bookmark/components/modal/edit-bookmark.modal.tsx
+++ b/src/layouts/bookmark/components/modal/edit-bookmark.modal.tsx
@@ -216,7 +216,7 @@ export function EditBookmarkModal({
 								onClick={onClose}
 								size="md"
 								disabled={isUpdating}
-								className="w-20 transition-colors duration-300 ease-in-out border-none shadow-none btn bg-base-300 hover:bg-error/10 text-base-content/80 hover:text-error"
+								className="w-20 transition-colors duration-300 ease-in-out border-none shadow-none bg-base-300 hover:bg-error/10 text-base-content/80 hover:text-error"
 								rounded={'2xl'}
 							>
 								لغو
@@ -232,7 +232,7 @@ export function EditBookmarkModal({
 								loading={isUpdating}
 								variant={'primary'}
 								rounded={'2xl'}
-								className="transition-colors duration-300 ease-in-out border-none shadow-none btn w-28"
+								className="transition-colors duration-300 ease-in-out border-none shadow-none w-28"
 							>
 								ذخیره
 							</Button>


### PR DESCRIPTION
## Summary
- Removed a leftover literal `btn` class from the Cancel/Save footer buttons in the add/edit bookmark modals and the advanced bookmark modal
- That class pulled in daisyUI's `.btn:active{ translate: 0 .5px }` rule, which nudged the button just enough to tip the tightly-fitted `overflow-y-auto` form container into showing a scrollbar for as long as the button was held down
- Added an AGENTS.md rule requiring a fresh branch (uncommitted) before any fix/feature work, so changes can be visually tested before committing

## Root cause
```css
.btn:active:not(.btn-active){ translate: 0 .5px }
```
Confirmed present in the compiled build output. The buttons already got all their sizing/color from the project's own `Button`/`buttonVariants`, so the `btn` class was redundant and only added this side effect.

## Testing
- [x] `npm run compile`
- [x] `npm test`
- [x] `npx biome check src`
- [x] `npm run build`
- [ ] Manual visual check by owner (add/edit bookmark modal, hold Cancel/Save, confirm no scrollbar flash)