### PR TITLE
fix: stop voice search from firing after panel is closed

### DIFF
--- a/src/layouts/search/voice/use-voice-search.ts
+++ b/src/layouts/search/voice/use-voice-search.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Analytics from '@/analytics'
 import { showToast } from '@/common/toast'
 
@@ -24,6 +24,11 @@ export function useVoiceSearch(
 	const [isListening, setIsListening] = useState(false)
 	const [currentTranscript, setCurrentTranscript] = useState('')
 	const recognitionRef = useRef<any>(null)
+	const onResultRef = useRef(onResult)
+
+	useEffect(() => {
+		onResultRef.current = onResult
+	}, [onResult])
 
 	const initSpeechRecognition = () => {
 		const SpeechRecognition =
@@ -61,7 +66,7 @@ export function useVoiceSearch(
 			setCurrentTranscript(fullTranscript)
 
 			if (finalTranscript) {
-				onResult(finalTranscript)
+				onResultRef.current(finalTranscript)
 				Analytics.event('voice_search_transcribed')
 			}
 		}
@@ -74,6 +79,9 @@ export function useVoiceSearch(
 
 		recognition.onend = () => {
 			setIsListening(false)
+			if (recognitionRef.current === recognition) {
+				recognitionRef.current = null
+			}
 		}
 
 		return recognition
@@ -94,9 +102,22 @@ export function useVoiceSearch(
 	}
 
 	const stopVoiceSearch = () => {
-		if (recognitionRef.current && isListening) {
-			recognitionRef.current.stop()
+		const recognition = recognitionRef.current
+		if (!recognition) return
+
+		recognition.onstart = null
+		recognition.onresult = null
+		recognition.onerror = null
+		recognition.onend = null
+		recognitionRef.current = null
+
+		try {
+			recognition.abort()
+		} catch (error) {
+			console.error('Error stopping speech recognition:', error)
 		}
+
+		setIsListening(false)
 	}
 
 	const clearTranscript = () => {


### PR DESCRIPTION
## Summary
- `stopVoiceSearch` only called `recognition.stop()` when `isListening` was true, but the `useEffect` cleanup in `voice-search.portal.tsx` (deps: `[selectedLanguage]`) only ever runs the closure captured at mount time, when `isListening` was still `false`. So on close/unmount, `stop()` was never actually called - the mic kept listening in the background and could still fire a real search once a final transcript came in, seconds after the panel was closed
- Same stale-instance behavior meant switching the recognition language after the first use silently had no effect
- `stopVoiceSearch` now nulls every handler + the ref and calls `abort()` unconditionally, so nothing can fire after a stop/close, and the next `startVoiceSearch` always builds a fresh instance with the current language
- `onResult` moved into a ref so the long-lived recognition callback always dispatches to the latest closure

## Testing
- [x] `npm run compile`
- [x] `npm test`
- [x] `npx biome check src`
- [x] `npm run build`
- [x] Manual visual check by owner (voice search panel close/click-outside no longer triggers a delayed search)