### PR TITLE
fix: raise overlays above open modals, and unclip the voice language menu

### DIFF
--- a/src/common/toast.tsx
+++ b/src/common/toast.tsx
@@ -5,6 +5,14 @@ import { playAlarm } from './play-alarm'
 import { translateError } from '@/common/utils/translate-error'
 import { Icon } from '../icons'
 import { cn } from '@/common/utils/cn'
+import { raiseToTopLayer } from '@/components/ui/portal/portal'
+
+export const TOAST_TOP_LAYER_ID = 'widgetify-toast-top-layer'
+
+function raiseToastLayer() {
+	if (typeof document === 'undefined') return
+	raiseToTopLayer(document.getElementById(TOAST_TOP_LAYER_ID))
+}
 
 export type ToastType = 'success' | 'error' | 'info' | 'warning'
 
@@ -169,6 +177,8 @@ export function showToast(
 	type: ToastType = 'info',
 	options?: ToastOptions
 ) {
+	raiseToastLayer()
+
 	const theme = TOAST_THEMES[type] || TOAST_THEMES.info
 	const title = options?.title ?? theme.defaultTitle
 	const actionText = options?.actionText ?? theme.defaultActionText
@@ -239,6 +249,8 @@ export function showCustomToast(
 	message: React.ReactNode | string,
 	options?: ToastOptions
 ) {
+	raiseToastLayer()
+
 	if (options?.sound !== false) {
 		playNativeToastSound('info')
 	}
@@ -253,6 +265,8 @@ export function showCustomToast(
 }
 
 export function showPreviewToast(itemName: string, onCancel: () => void): string {
+	raiseToastLayer()
+
 	const id = `preview-${Date.now()}`
 
 	playNativeToastSound('info')

--- a/src/components/ui/dropdown/dropdown.tsx
+++ b/src/components/ui/dropdown/dropdown.tsx
@@ -208,51 +208,49 @@ export function Dropdown({
 				{trigger}
 			</div>
 
-			<Portal>
-				<Presence>
-					{isOpen && !disabled && (
-						<div
-							key="dropdown-layer"
-							id={id}
-							className="fixed inset-0 pointer-events-none"
-							style={{ zIndex: 99999 }}
+			<Presence>
+				{isOpen && !disabled && (
+					<Portal
+						topLayer
+						key="dropdown-layer"
+						id={id}
+						style={{ zIndex: 99999 }}
+					>
+						<Motion.div
+							ref={dropdownContentRef}
+							className={`fixed shadow-xl overflow-hidden rounded-2xl bg-base-200 backdrop-blur-xl ${isReady ? 'pointer-events-auto' : 'pointer-events-none'} ${dropdownClassName}`}
+							initial={{ opacity: 0, scale: 0.95 }}
+							animate={{
+								opacity: isReady ? 1 : 0,
+								scale: isReady ? 1 : 0.95,
+							}}
+							exit={{ opacity: 0, scale: 0.95 }}
+							transition={{ duration: 0.15, ease: 'easeOut' }}
+							style={{
+								maxHeight,
+								width:
+									width === 'auto'
+										? 'auto'
+										: width === 'full'
+											? '100%'
+											: width,
+								minWidth: width === 'auto' ? '150px' : undefined,
+								top: dropdownPosition.top,
+								left: dropdownPosition.left,
+								visibility: isReady ? 'visible' : 'hidden',
+								zIndex: 99999,
+							}}
 						>
-							<Motion.div
-								ref={dropdownContentRef}
-								className={`fixed shadow-xl overflow-hidden rounded-2xl bg-base-200 backdrop-blur-xl ${isReady ? 'pointer-events-auto' : 'pointer-events-none'} ${dropdownClassName}`}
-								initial={{ opacity: 0, scale: 0.95 }}
-								animate={{
-									opacity: isReady ? 1 : 0,
-									scale: isReady ? 1 : 0.95,
-								}}
-								exit={{ opacity: 0, scale: 0.95 }}
-								transition={{ duration: 0.15, ease: 'easeOut' }}
-								style={{
-									maxHeight,
-									width:
-										width === 'auto'
-											? 'auto'
-											: width === 'full'
-												? '100%'
-												: width,
-									minWidth: width === 'auto' ? '150px' : undefined,
-									top: dropdownPosition.top,
-									left: dropdownPosition.left,
-									visibility: isReady ? 'visible' : 'hidden',
-									zIndex: 99999,
-								}}
+							<div
+								className="overflow-y-auto overscroll-contain scrollbar-none"
+								style={{ maxHeight }}
 							>
-								<div
-									className="overflow-y-auto overscroll-contain scrollbar-none"
-									style={{ maxHeight }}
-								>
-									{dropdownContent}
-								</div>
-							</Motion.div>
-						</div>
-					)}
-				</Presence>
-			</Portal>
+								{dropdownContent}
+							</div>
+						</Motion.div>
+					</Portal>
+				)}
+			</Presence>
 		</div>
 	)
 }

--- a/src/components/ui/modal/modal.variants.ts
+++ b/src/components/ui/modal/modal.variants.ts
@@ -13,10 +13,10 @@ export const modalBoxVariants = cva(
 		'transition-discrete',
 		'opacity-0',
 		'scale-95',
-		'group-open:opacity-100',
-		'group-open:scale-100',
-		'starting:group-open:opacity-0',
-		'starting:group-open:scale-95',
+		'group-open/modal:opacity-100',
+		'group-open/modal:scale-100',
+		'starting:group-open/modal:opacity-0',
+		'starting:group-open/modal:scale-95',
 	],
 	{
 		variants: {
@@ -67,7 +67,7 @@ export type ModalScrollVariant = typeof modalScrollVariants
 export const modalDialogVariants = cva([
 	'modal',
 	'modal-middle',
-	'group',
+	'group/modal',
 	'p-2',
 	'md:p-4',
 	'transition-opacity',

--- a/src/components/ui/portal/portal.tsx
+++ b/src/components/ui/portal/portal.tsx
@@ -1,12 +1,110 @@
-import type { ReactNode } from 'react'
+import {
+	useEffect,
+	useLayoutEffect,
+	useState,
+	type CSSProperties,
+	type ReactNode,
+} from 'react'
 import { createPortal } from 'react-dom'
 
 export interface PortalProps {
 	children: ReactNode
 	container?: Element | null
+	topLayer?: boolean
+	id?: string
+	className?: string
+	style?: CSSProperties
 }
 
-export function Portal({ children, container = document.body }: PortalProps) {
+const TOP_LAYER_HOST_CSS =
+	'position:fixed;inset:0;width:auto;height:auto;max-width:none;max-height:none;margin:0;padding:0;border:none;background:transparent;overflow:visible;color:inherit;pointer-events:none;'
+
+function topmostModalDialog(): HTMLElement | null {
+	let topmost: HTMLElement | null = null
+
+	try {
+		for (const dialog of document.querySelectorAll('dialog[open]')) {
+			if (dialog.matches(':modal')) topmost = dialog as HTMLElement
+		}
+	} catch {
+		return null
+	}
+
+	return topmost
+}
+
+export function raiseToTopLayer(host: HTMLElement | null) {
+	if (!host) return
+
+	const parent = topmostModalDialog() ?? document.body
+
+	if (host.parentElement !== parent) {
+		parent.appendChild(host)
+
+		if (parent !== document.body) {
+			parent.addEventListener('close', () => raiseToTopLayer(host), {
+				once: true,
+			})
+		}
+	}
+
+	if (typeof host.showPopover !== 'function') return
+
+	try {
+		host.hidePopover()
+	} catch {}
+
+	try {
+		host.showPopover()
+	} catch {}
+}
+
+type TopLayerHostProps = Pick<PortalProps, 'children' | 'id' | 'className' | 'style'>
+
+function TopLayerHost({ children, id, className, style }: TopLayerHostProps) {
+	const [host] = useState(() => {
+		const el = document.createElement('div')
+		el.setAttribute('popover', 'manual')
+		return el
+	})
+
+	useLayoutEffect(() => {
+		if (id) host.id = id
+		host.className = className ?? ''
+		host.style.cssText = TOP_LAYER_HOST_CSS
+		if (style) Object.assign(host.style, style)
+	})
+
+	useEffect(() => {
+		raiseToTopLayer(host)
+
+		return () => {
+			try {
+				host.hidePopover()
+			} catch {}
+			host.remove()
+		}
+	}, [host])
+
+	return createPortal(children, host)
+}
+
+export function Portal({
+	children,
+	container = document.body,
+	topLayer,
+	id,
+	className,
+	style,
+}: PortalProps) {
+	if (topLayer) {
+		return (
+			<TopLayerHost id={id} className={className} style={style}>
+				{children}
+			</TopLayerHost>
+		)
+	}
+
 	if (!container) return null
 
 	return createPortal(children, container)

--- a/src/components/ui/tooltip/clickable-tooltip.tsx
+++ b/src/components/ui/tooltip/clickable-tooltip.tsx
@@ -1,7 +1,7 @@
 import { Motion as motion, Presence } from '@/common/motion'
 
 import { type ReactNode, useEffect, useRef, useState, type RefObject } from 'react'
-import ReactDOM from 'react-dom'
+import { Portal } from '../portal/portal'
 
 type Position =
 	| 'top'
@@ -208,12 +208,12 @@ const ClickableTooltip = ({
 
 	return (
 		<>
-			{ReactDOM.createPortal(
+			<Portal topLayer>
 				<Presence mode="wait">
 					{isOpen && (
 						<motion.div
 							ref={tooltipRef}
-							className={`fixed text-xs  max-w-xs  bg-transparent! shadow-md bg-glass rounded-2xl ${contentClassName}`}
+							className={`fixed text-xs pointer-events-auto max-w-xs  bg-transparent! shadow-md bg-glass rounded-2xl ${contentClassName}`}
 							style={{
 								left: tooltipCoords.x,
 								top: tooltipCoords.y,
@@ -228,9 +228,8 @@ const ClickableTooltip = ({
 							{content}
 						</motion.div>
 					)}
-				</Presence>,
-				document.body
-			)}
+				</Presence>
+			</Portal>
 		</>
 	)
 }

--- a/src/components/ui/tooltip/tooltip.tsx
+++ b/src/components/ui/tooltip/tooltip.tsx
@@ -1,7 +1,7 @@
 import { twMerge } from 'tailwind-merge'
 import { Motion as motion, Presence } from '@/common/motion'
 import { type ReactNode, useEffect, useRef, useState } from 'react'
-import ReactDOM from 'react-dom'
+import { Portal } from '../portal/portal'
 
 type Position =
 	| 'top'
@@ -217,12 +217,12 @@ export const Tooltip = ({
 				{children}
 			</div>
 
-			{(alwaysShow || isVisible) &&
-				ReactDOM.createPortal(
+			{(alwaysShow || isVisible) && (
+				<Portal topLayer>
 					<Presence>
 						<motion.div
 							ref={tooltipRef}
-							className={`tooltip fixed rounded-lg py-1.5 px-3 text-xs max-w-xs bg-content shadow-lg z-popover  ${contentClassName}`}
+							className={`tooltip fixed pointer-events-auto rounded-lg py-1.5 px-3 text-xs max-w-xs bg-content shadow-lg z-popover  ${contentClassName}`}
 							style={{
 								left: tooltipCoords.x,
 								top: tooltipCoords.y,
@@ -238,9 +238,9 @@ export const Tooltip = ({
 							{content}
 							<div className={getArrowClasses(calculatedPosition)} />
 						</motion.div>
-					</Presence>,
-					document.body
-				)}
+					</Presence>
+				</Portal>
+			)}
 		</>
 	)
 }

--- a/src/layouts/bookmark/components/modal/bookmark-context-menu.tsx
+++ b/src/layouts/bookmark/components/modal/bookmark-context-menu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { createPortal } from 'react-dom'
+import { Portal } from '@/components/ui'
 import { Icon } from '@/src/icons'
 
 interface BookmarkContextMenuProps {
@@ -60,62 +60,63 @@ export function BookmarkContextMenu({
 		Math.max(10, window.innerHeight - MENU_HEIGHT - 10)
 	)
 
-	return createPortal(
-		<div
-			ref={menuRef}
-			style={{
-				position: 'fixed',
-				left: adjustedLeft,
-				top: adjustedTop,
-				zIndex: 99999,
-			}}
-			className="w-[148px] bg-base-200/95 backdrop-blur-md rounded-2xl shadow-2xl border border-base-content/10 p-1.5 text-right text-xs flex flex-col gap-1 select-none animate-in fade-in zoom-in-95 duration-150"
-			onClick={(e) => e.stopPropagation()}
-			onContextMenu={(e) => {
-				e.preventDefault()
-				e.stopPropagation()
-			}}
-		>
-			{onOpenInNewTab && (
+	return (
+		<Portal topLayer>
+			<div
+				ref={menuRef}
+				style={{
+					position: 'fixed',
+					left: adjustedLeft,
+					top: adjustedTop,
+					zIndex: 99999,
+				}}
+				className="w-[148px] pointer-events-auto bg-base-200/95 backdrop-blur-md rounded-2xl shadow-2xl border border-base-content/10 p-1.5 text-right text-xs flex flex-col gap-1 select-none animate-in fade-in zoom-in-95 duration-150"
+				onClick={(e) => e.stopPropagation()}
+				onContextMenu={(e) => {
+					e.preventDefault()
+					e.stopPropagation()
+				}}
+			>
+				{onOpenInNewTab && (
+					<button
+						type="button"
+						onClick={() => {
+							onOpenInNewTab()
+							onClose()
+						}}
+						className="w-full px-2.5 py-1.5 flex items-center justify-between cursor-pointer rounded-xl transition-colors duration-150 text-content hover:bg-base-300 text-xs"
+					>
+						<span className="font-medium">در تب جدید</span>
+						<Icon name="plus" size={13} className="text-muted" />
+					</button>
+				)}
+
 				<button
 					type="button"
 					onClick={() => {
-						onOpenInNewTab()
+						onEdit()
 						onClose()
 					}}
 					className="w-full px-2.5 py-1.5 flex items-center justify-between cursor-pointer rounded-xl transition-colors duration-150 text-content hover:bg-base-300 text-xs"
 				>
-					<span className="font-medium">در تب جدید</span>
-					<Icon name="plus" size={13} className="text-muted" />
+					<span className="font-medium">ویرایش</span>
+					<Icon name="pen" size={12} className="text-muted" />
 				</button>
-			)}
 
-			<button
-				type="button"
-				onClick={() => {
-					onEdit()
-					onClose()
-				}}
-				className="w-full px-2.5 py-1.5 flex items-center justify-between cursor-pointer rounded-xl transition-colors duration-150 text-content hover:bg-base-300 text-xs"
-			>
-				<span className="font-medium">ویرایش</span>
-				<Icon name="pen" size={12} className="text-muted" />
-			</button>
+				<div className="h-px bg-base-content/10 my-0.5" />
 
-			<div className="h-px bg-base-content/10 my-0.5" />
-
-			<button
-				type="button"
-				onClick={() => {
-					onDelete()
-					onClose()
-				}}
-				className="w-full px-2.5 py-1.5 flex items-center justify-between cursor-pointer rounded-xl transition-colors duration-150 text-error hover:bg-error/15 text-xs"
-			>
-				<span className="font-medium">حذف</span>
-				<Icon name="trash" size={13} className="text-error" />
-			</button>
-		</div>,
-		document.body
+				<button
+					type="button"
+					onClick={() => {
+						onDelete()
+						onClose()
+					}}
+					className="w-full px-2.5 py-1.5 flex items-center justify-between cursor-pointer rounded-xl transition-colors duration-150 text-error hover:bg-error/15 text-xs"
+				>
+					<span className="font-medium">حذف</span>
+					<Icon name="trash" size={13} className="text-error" />
+				</button>
+			</div>
+		</Portal>
 	)
 }

--- a/src/layouts/search/voice/voice-search.portal.tsx
+++ b/src/layouts/search/voice/voice-search.portal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useVoiceSearch } from './use-voice-search'
-import { Portal } from '@/components/ui'
+import { Dropdown, Portal } from '@/components/ui'
 import { Icon } from '@/src/icons'
 
 interface VoiceSearchPortalProps {
@@ -23,7 +23,6 @@ export function VoiceSearchPortal({
 	portalRef,
 }: VoiceSearchPortalProps) {
 	const [selectedLanguage, setSelectedLanguage] = useState<Language>('fa-IR')
-	const [isLanguageMenuOpen, setIsLanguageMenuOpen] = useState(false)
 
 	const { isListening, currentTranscript, startVoiceSearch, stopVoiceSearch } =
 		useVoiceSearch((result) => {
@@ -86,32 +85,27 @@ export function VoiceSearchPortal({
 					</div>
 
 					<div className="flex items-center justify-between w-full pt-4 mt-4 border-t border-base-content/5">
-						<div className="relative">
-							<button
-								onClick={() => setIsLanguageMenuOpen(!isLanguageMenuOpen)}
-								className="flex cursor-pointer items-center gap-2 px-3 py-1.5 hover:bg-base-200 rounded-xl transition-colors text-xs font-bold text-base-content/60"
-							>
-								<Icon name="settings" size={14} />
-								{languages.find((l) => l.code === selectedLanguage)?.name}
-							</button>
-
-							{isLanguageMenuOpen && (
-								<div className="absolute bottom-full mb-2 left-0 bg-base-100 border border-base-content/10 shadow-xl rounded-xl overflow-hidden min-w-[120px]">
-									{languages.map((lang) => (
-										<button
-											key={lang.code}
-											onClick={() => {
-												setSelectedLanguage(lang.code)
-												setIsLanguageMenuOpen(false)
-											}}
-											className="w-full cursor-pointer px-4 py-2.5 text-right text-xs font-bold hover:bg-base-200 transition-colors"
-										>
-											{lang.name}
-										</button>
-									))}
+						<Dropdown
+							position="top-right"
+							width="120px"
+							dropdownClassName="text-xs font-bold"
+							trigger={
+								<div className="flex cursor-pointer items-center gap-2 px-3 py-1.5 hover:bg-base-200 rounded-xl transition-colors text-xs font-bold text-base-content/60">
+									<Icon name="settings" size={14} />
+									{
+										languages.find((l) => l.code === selectedLanguage)
+											?.name
+									}
 								</div>
-							)}
-						</div>
+							}
+							options={languages.map((lang) => ({
+								id: lang.code,
+								label: lang.name,
+							}))}
+							onOptionSelect={(option) =>
+								setSelectedLanguage(option.id as Language)
+							}
+						/>
 
 						<button
 							onClick={() =>

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -3,6 +3,8 @@ import { Toaster } from 'react-hot-toast'
 import Analytics from '@/analytics'
 import { purgeDeprecatedStorageKeys } from '@/common/storage'
 import { listenEvent } from '@/common/utils/call-event'
+import { TOAST_TOP_LAYER_ID } from '@/common/toast'
+import { Portal } from '@/components/ui'
 import {
 	GeneralSettingProvider,
 	useGeneralSetting,
@@ -39,23 +41,25 @@ export function RootLayout() {
 						<Main></Main>
 					</WallpaperProvider>
 				</GeneralSettingProvider>
-				<Toaster
-					toastOptions={{
-						error: {
-							style: {
-								backgroundColor: 'var(--color-error)',
-								color: 'var(--color-error-content)',
+				<Portal topLayer id={TOAST_TOP_LAYER_ID} style={{ zIndex: 100000 }}>
+					<Toaster
+						toastOptions={{
+							error: {
+								style: {
+									backgroundColor: 'var(--color-error)',
+									color: 'var(--color-error-content)',
+								},
 							},
-						},
-						success: {
-							style: {
-								backgroundColor: 'var(--color-success)',
-								color: 'var(--color-success-content)',
+							success: {
+								style: {
+									backgroundColor: 'var(--color-success)',
+									color: 'var(--color-success-content)',
+								},
 							},
-						},
-						duration: 5000,
-					}}
-				/>
+							duration: 5000,
+						}}
+					/>
+				</Portal>
 			</IconProvider>
 		</div>
 	)


### PR DESCRIPTION
## Problem
Overlays rendered behind an open modal, and once lifted above it they still could not be clicked — clicking a toast button closed the modal instead of pressing the button. Reported for toasts, the habit widget dropdown, the bookmark three-dot menu, and the voice search language picker.

## Root cause
`showModal()` does two separate things, and both bit us:

1. Moves the dialog into the browser **top layer** — no `z-index` can beat that.
2. Marks everything outside the dialog **inert**, so clicks pass straight through overlays and land on the dialog, matching the backdrop-close check `e.target === dialogRef.current`.

## Changes
- **`Portal` gains a `topLayer` flag** (existing component, no new files). It renders into a host it owns, promotes it via the Popover API so it paints above an open dialog, and appends it to the topmost open modal dialog — the only non-inert region. A one-shot `close` listener moves the host back to `document.body` so a toast already on screen survives the modal closing.
- The host is created imperatively, not as JSX: React would otherwise own it as a portal root and throw `NotFoundError` on unmount once we re-parented it.
- Host defaults to `pointer-events: none` (it spans the viewport, so otherwise it would swallow every click); children opt back in. `react-hot-toast` already marks each toast wrapper `> * { pointer-events: auto }`.
- The toaster mounts at startup, before any modal exists, so every toast entry point re-raises the layer first.
- Applied to: toast layer, `Dropdown`, bookmark context menu, `Tooltip`, `ClickableTooltip`.
- **Voice search language menu** was a separate bug: a hand-rolled `absolute` popover clipped by the panel's `overflow-hidden`. Replaced with the `Dropdown` primitive, per AGENTS.md.

## Also fixed here: every hover overlay in a modal revealing at once
In the shop, moving the pointer anywhere inside the modal revealed the "پیش‌نمایش" button on **every** wallpaper simultaneously.

Those buttons are plain CSS hover (`opacity-0 group-hover:opacity-100`), and each card does carry its own `group`. But `group-hover` compiles to:

```css
.group-hover\:opacity-100:is(:where(.group):hover *)
```

which matches **any** hovered ancestor carrying `.group`, not the nearest one — and `modalDialogVariants` puts `group` on the `<dialog>` itself so `modal-box` can drive its open animation from `group-open`. The dialog wraps everything and covers the viewport, so entering it fired every `group-hover` inside.

The dialog now uses a **named group** (`group/modal`, with the four utilities as `group-open/modal`), so its marker is no longer `.group`. Naming the modal's group rather than the cards' is what fixes the whole class: `group-open` appears 4 times in one file, `group-hover` across 39 files — the leak affected every modal, not just wallpapers.

**This one predates the branch**; `group` has been on the dialog all along.

## Deliberately left out
- `canvas-edit-toolbar.tsx` still portals straight to `document.body`. It *belongs* behind a modal — opening "add widget" from it should cover it.
- The sticker popover in `advanced.modal.tsx` is also a hand-rolled `absolute` popover prone to the same clipping, but it was not reported and is not inert, so it is left as-is.

## Testing
- [x] `npm run compile`
- [x] `npm test`
- [x] `npx biome check src`
- [x] `npm run build`
- [x] Modal open/close animation verified intact in the built CSS — all four `group-open/modal` rules, both `@starting-style` blocks included
- [x] Manual check by owner: toast action button over the settings modal, habit widget dropdown, bookmark three-dot menu over the folder modal, voice search language menu, and the shop wallpaper hover

> Note: [#438](https://github.com/widgetify-app/widgetify-extension/pull/438) also edits `modalDialogVariants`. Whichever merges second will conflict; resolve by blending — that PR's shortened array plus `group/modal` in place of `group`.
