### PR TITLE
fix: stop frosted surfaces flashing on glass and icy themes

### DIFF
--- a/src/components/ui/modal/modal.variants.ts
+++ b/src/components/ui/modal/modal.variants.ts
@@ -64,18 +64,6 @@ export const modalScrollVariants = cva(
 
 export type ModalScrollVariant = typeof modalScrollVariants
 
-export const modalDialogVariants = cva([
-	'modal',
-	'modal-middle',
-	'group',
-	'p-2',
-	'md:p-4',
-	'transition-opacity',
-	'duration-[var(--modal-duration,300ms)]',
-	'transition-discrete',
-	'opacity-0',
-	'open:opacity-100',
-	'starting:open:opacity-0',
-])
+export const modalDialogVariants = cva(['modal', 'modal-middle', 'group', 'p-2', 'md:p-4'])
 
 export type ModalDialogVariant = typeof modalDialogVariants

--- a/src/components/user/user-card-portal.tsx
+++ b/src/components/user/user-card-portal.tsx
@@ -71,9 +71,9 @@ export function UserCardPortal({
 						key="user-card"
 						ref={cardRef}
 						className="fixed z-popover shadow-lg min-w-64 max-w-64"
-						initial={{ opacity: 0, scale: 0.95, x: '-50%' }}
-						animate={{ opacity: 1, scale: 1, x: '-50%' }}
-						exit={{ opacity: 0, scale: 0.95, x: '-50%' }}
+						initial={{ scale: 0.95, x: '-50%' }}
+						animate={{ scale: 1, x: '-50%' }}
+						exit={{ scale: 0.95, x: '-50%' }}
 						transition={{ duration: 0.15, ease: 'easeOut' }}
 						style={{
 							top: `${position.top}px`,

--- a/src/layouts/navbar/navbar.layout.tsx
+++ b/src/layouts/navbar/navbar.layout.tsx
@@ -151,8 +151,8 @@ export function NavbarLayout(): JSX.Element {
 				className={`fixed z-60  -translate-x-1/2 left-1/2 w-full px-2 md:px-8 lg:px-4 max-w-[1080px] transition-all duration-500 ease-[cubic-bezier(0.23,1,0.32,1)] 
 					${
 						showNavbar
-							? 'bottom-2 opacity-100 scale-100'
-							: '-bottom-32 opacity-0 scale-95 pointer-events-none'
+							? 'bottom-2 scale-100'
+							: '-bottom-32 scale-95 pointer-events-none'
 					}`}
 			>
 				<div

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -109,12 +109,12 @@ function Main() {
 					<Presence mode="wait">
 						<motion.div
 							key={page}
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 1 }}
-							exit={{ opacity: 0 }}
+							initial={{ y: 10 }}
+							animate={{ y: 0 }}
+							exit={{ y: 10 }}
 							transition={{
-								duration: 0.15,
-								ease: 'linear',
+								duration: 0.2,
+								ease: [0.22, 1, 0.36, 1],
 							}}
 							className="flex w-full h-full"
 						>


### PR DESCRIPTION
## Problem
On the glass and icy themes, frosted surfaces loaded in two stages: they first appeared with the wallpaper showing through sharp and the colours washed out, then snapped to the correct blurred look. Reported for modals, the explorer cards, the home widgets, and the bottom navbar as it opens.

## Root cause
An element with `opacity` below 1 forms a **backdrop root**. Any descendant with `backdrop-filter` then stops sampling the page behind it and renders as nothing — until the opacity reaches exactly `1`, when the backdrop root disappears and the blur snaps in. That snap is the visible "second stage".

Only glass and icy show it because they are the only themes that set `backdrop-filter`; `light`, `dark`, `zarna` and `esteghlal` have zero occurrences.

Four ancestors were doing it:

| Where | Ancestor animating opacity | Glass descendant |
|---|---|---|
| `modal.variants.ts` | custom fade on the `<dialog>` | `.modal-box` |
| `root.tsx` | page-switch wrapper | every card/widget on the page |
| `navbar.layout.tsx` | navbar container, 500ms | `<nav class="bg-glass">` |
| `user-card-portal.tsx` | motion wrapper | `UserCard` (`bg-glass`) |

The modal had a second defect in the same lines: `transition-opacity` sets `transition-property: opacity`, which as a Tailwind utility **overrode daisyUI's own `.modal` transition shorthand**, so the backdrop dim was snapping instead of fading.

## Changes
- **Modal**: removed the custom fade entirely. daisyUI already animates modals in both directions — `.modal` handles `visibility` with `allow-discrete` plus the `background-color` dim, and `.modal[open] .modal-box` handles opacity/translate/scale, re-declaring the very same `scale: 95%`.
- **Navbar / user card**: kept the motion, dropped only `opacity`. Transforms do not create a backdrop root. The navbar still slides and scales, and is hidden off-screen by `-bottom-32` + `pointer-events-none`, so it never needed opacity to disappear.
- **Page switch**: now rises (`y: 10 → 0`) instead of fading, with an ease-out curve. One animation for all themes.

## Notes
- `scale` was tried first for the page switch and rejected: scaling re-rasterises text every frame, which made widgets shimmer on the way back to home. A translate is composited without re-rasterising.
- `exit` deliberately matches `initial` — with `mode="wait"` the outgoing page leaves before the incoming one arrives, so differing values show a jump at the swap.
- Optimisation mode is unaffected: `html.optimal-mode` already forces `transition-duration: 0s` globally in `index.css`.
- Left alone: the navbar handle button and the search/tooltip popovers carry `bg-glass` on the *same* element they animate, which is fine — an element's own opacity does not gate its own `backdrop-filter`. A nested `bg-glass` inside the `Dropdown` (settings-dropdown, notifications) is technically affected, but its wrapper already applies `backdrop-blur-xl`, so it is redundant and invisible in practice.

## Testing
- [x] `npm run compile`
- [x] `npm test`
- [x] `npx biome check src`
- [x] `npm run build`
- [x] Manual visual check by owner: modals, explorer cards, home widgets, bottom navbar open, page switching — on glass/icy and on a normal theme