### PR TITLE
perf: cut per-frame cost of widget layout edit mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -275,18 +275,43 @@ img {
 .animate-widget-wiggle-a {
   animation: widget-wiggle 0.46s ease-in-out infinite alternate;
   transform-origin: 50% 10%;
+  will-change: transform;
 }
 
 .animate-widget-wiggle-b {
   animation: widget-wiggle-alt 0.48s ease-in-out infinite alternate;
   animation-delay: -0.15s;
   transform-origin: 50% 10%;
+  will-change: transform;
 }
 
 .animate-widget-wiggle-c {
   animation: widget-wiggle 0.52s ease-in-out infinite alternate;
   animation-delay: -0.3s;
   transform-origin: 50% 10%;
+  will-change: transform;
+}
+
+#widgets-canvas.canvas-editing .bg-glass {
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+
+html.optimal-mode .animate-widget-wiggle-a,
+html.optimal-mode .animate-widget-wiggle-b,
+html.optimal-mode .animate-widget-wiggle-c {
+  animation: none;
+  will-change: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+  .animate-widget-wiggle-a,
+  .animate-widget-wiggle-b,
+  .animate-widget-wiggle-c {
+    animation: none;
+    will-change: auto;
+  }
 }
 
 .widget-canvas-item-transition {

--- a/src/layouts/bookmark/components/bookmark-folder.tsx
+++ b/src/layouts/bookmark/components/bookmark-folder.tsx
@@ -72,7 +72,7 @@ export function FolderBookmarkItem({
 	return (
 		<div
 			className={cn(
-				'relative flex w-full h-full overflow-hidden',
+				'relative flex w-full h-full overflow-hidden rounded-widget',
 				isDragging && 'opacity-50'
 			)}
 		>

--- a/src/layouts/widgets/canvas/free-widget-canvas.tsx
+++ b/src/layouts/widgets/canvas/free-widget-canvas.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { callEvent, listenEvent } from '@/common/utils/call-event'
+import { cn } from '@/common/utils/cn'
 import { useFreeWidgets } from '@/context/free-widget/free-widget.context'
 import { useContainerSize } from '@/hooks/use-container-size'
 import { getCanvasHeight } from '../grid-geometry'
@@ -192,7 +193,10 @@ export function FreeWidgetCanvas() {
 		<div
 			ref={containerRef}
 			id="widgets-canvas"
-			className="relative w-full select-none"
+			className={cn(
+				'relative w-full select-none',
+				canvasMode === 'edit' && 'canvas-editing'
+			)}
 			onPointerDown={handleCanvasPointerDown}
 			onClick={handleCanvasClick}
 			onContextMenu={handleCanvasContextMenu}

--- a/src/layouts/widgets/canvas/grid-overlay.tsx
+++ b/src/layouts/widgets/canvas/grid-overlay.tsx
@@ -42,7 +42,7 @@ function GridOverlayImpl({
 								width: `${cellWidth}px`,
 								height: `${cellHeight}px`,
 							}}
-							className="border border-dashed rounded-widget border-base-content/15 bg-base-300/10"
+							className="border border-dashed rounded-widget border-base-content/26 bg-base-300/10"
 						/>
 					))}
 				</div>

--- a/src/layouts/widgets/widget-container.tsx
+++ b/src/layouts/widgets/widget-container.tsx
@@ -22,7 +22,7 @@ export function WidgetContainer({
 
 	return (
 		<div
-			className={`widget-outer relative h-full w-full overflow-hidden ${className}`}
+			className={`widget-outer relative h-full w-full overflow-hidden rounded-widget ${className}`}
 		>
 			<div
 				className={`h-full w-full m-auto flex flex-col overflow-hidden ${background ? `bg-content bg-glass ${padding ? 'p-2' : 'p-0'} rounded-widget` : ''} ${contentClassName} ${canvasMode === 'edit' ? 'pointer-events-none select-none' : ''}`}


### PR DESCRIPTION
## Problem
Users on weaker machines reported the canvas lagging while editing the widget layout. The lag starts **the moment edit mode opens**, before anything is dragged.

## What is not the problem
The drag path is already well optimised, and worth stating so it does not get "fixed" later:

- previews are throttled through `requestAnimationFrame` and only run the layout engine when the target grid cell actually changes
- `reconcileIdentity` preserves the object identity of untouched widgets, so the `memo` on `CanvasWidgetOuter` genuinely holds
- a preview never touches storage or the server — only the drop commits

The cost is rendering.

## Root cause
In edit mode every unselected widget gets an infinite rotation:

```css
animation: widget-wiggle 0.46s ease-in-out infinite alternate;
```

and every widget contains a `WidgetContainer` carrying `bg-glass`, which on the glass and icy themes resolves to `backdrop-filter: blur(16px) saturate(150%)`.

**Rotating an element that contains a `backdrop-filter` forces the browser to re-sample and re-blur the backdrop every frame, once per widget.** Ten widgets means ten blur passes per frame at 60fps. Nothing set `will-change` either, so rounded corners, borders and text were re-rasterised on the main thread each frame on top of that.

## Changes
1. **Live blur is dropped while editing.** The canvas root gains a `canvas-editing` class; `#widgets-canvas.canvas-editing .bg-glass` clears `backdrop-filter`. Specificity is `(1,2,0)` against the theme rule's `(0,2,0)`, so it wins regardless of file order, and `background-color` is untouched — widgets keep their translucent look, they just stop recomputing a blur 60×/sec while being rearranged.
2. **`will-change: transform`** on the wiggle classes so the rotation is composited rather than re-rasterised.
3. **Wiggle switched off under `html.optimal-mode` and `prefers-reduced-motion`.** `optimal-mode` only zeroed `transition-duration`, so the single most expensive thing on the page kept running for exactly the users most likely to have enabled it. Scoped to the three wiggle classes, leaving the deliberate choice to keep keyframe animations alive for spinners and the notification ping intact.

Also raises the edit-mode grid border from `border-base-content/15` to `/26` — on glass/icy `--color-base-content` is near-white, so 15% white all but vanished over a light wallpaper.

## Deliberately left out
Widgets still run live in edit mode — clocks tick, pets move. Pausing them is likely the next win, but it touches each widget individually, so it belongs in its own change.

## Testing
- [x] `npm run compile`
- [x] `npm test`
- [x] `npx biome check src`
- [x] `npm run build`
- [x] All four new CSS rules verified present in the built `newtab-*.css` (this repo has a history of classes compiling to nothing)
- [x] Manual check by owner on a glass theme